### PR TITLE
Refactor tests

### DIFF
--- a/tests/Factory/SentryFactoryTest.php
+++ b/tests/Factory/SentryFactoryTest.php
@@ -31,7 +31,7 @@ class SentryFactoryTest extends \PHPUnit\Framework\TestCase
 
 		try {
 			$factory->getSentry($sentryIdentificator);
-			Assert::fail();
+			Assert::fail('Exception expected');
 		} catch (\Consistence\Sentry\Factory\NoSentryForIdentificatorException $e) {
 			Assert::assertSame($sentryIdentificator, $e->getSentryIdentificator());
 		}

--- a/tests/Factory/SentryFactoryTest.php
+++ b/tests/Factory/SentryFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Consistence\Sentry\Factory;
 
 use Consistence\Sentry\Metadata\SentryIdentificator;
+use PHPUnit\Framework\Assert;
 
 class SentryFactoryTest extends \PHPUnit\Framework\TestCase
 {
@@ -13,7 +14,7 @@ class SentryFactoryTest extends \PHPUnit\Framework\TestCase
 	{
 		$factory = $this->createMock(SentryFactory::class);
 		$factory
-			->expects($this->once())
+			->expects(self::once())
 			->method('getSentry');
 
 		$factory->getSentry(new SentryIdentificator('string'));
@@ -24,15 +25,15 @@ class SentryFactoryTest extends \PHPUnit\Framework\TestCase
 		$sentryIdentificator = new SentryIdentificator('string');
 		$factory = $this->createMock(SentryFactory::class);
 		$factory
-			->expects($this->once())
+			->expects(self::once())
 			->method('getSentry')
-			->will($this->throwException(new \Consistence\Sentry\Factory\NoSentryForIdentificatorException($sentryIdentificator)));
+			->will(self::throwException(new \Consistence\Sentry\Factory\NoSentryForIdentificatorException($sentryIdentificator)));
 
 		try {
 			$factory->getSentry($sentryIdentificator);
-			$this->fail();
+			Assert::fail();
 		} catch (\Consistence\Sentry\Factory\NoSentryForIdentificatorException $e) {
-			$this->assertSame($sentryIdentificator, $e->getSentryIdentificator());
+			Assert::assertSame($sentryIdentificator, $e->getSentryIdentificator());
 		}
 	}
 

--- a/tests/Factory/Simple/SimpleSentryFactoryTest.php
+++ b/tests/Factory/Simple/SimpleSentryFactoryTest.php
@@ -20,22 +20,70 @@ class SimpleSentryFactoryTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function sentryIdentificatorToSentryDataProvider(): Generator
 	{
-		yield [new SentryIdentificator('string'), new SimpleType()];
-		yield [new SentryIdentificator('int'), new SimpleType()];
-		yield [new SentryIdentificator('bool'), new SimpleType()];
-		yield [new SentryIdentificator('float'), new SimpleType()];
-		yield [new SentryIdentificator('integer'), new SimpleType()];
-		yield [new SentryIdentificator('boolean'), new SimpleType()];
-		yield [new SentryIdentificator('mixed'), new SimpleType()];
-		yield [new SentryIdentificator('DateTimeImmutable'), new SimpleType()];
-		yield [new SentryIdentificator('string[]'), new CollectionType()];
-		yield [new SentryIdentificator('int[]'), new CollectionType()];
-		yield [new SentryIdentificator('bool[]'), new CollectionType()];
-		yield [new SentryIdentificator('float[]'), new CollectionType()];
-		yield [new SentryIdentificator('integer[]'), new CollectionType()];
-		yield [new SentryIdentificator('boolean[]'), new CollectionType()];
-		yield [new SentryIdentificator('mixed[]'), new CollectionType()];
-		yield [new SentryIdentificator('DateTimeImmutable[]'), new CollectionType()];
+		yield [
+			new SentryIdentificator('string'),
+			new SimpleType(),
+		];
+		yield [
+			new SentryIdentificator('int'),
+			new SimpleType(),
+		];
+		yield [
+			new SentryIdentificator('bool'),
+			new SimpleType(),
+		];
+		yield [
+			new SentryIdentificator('float'),
+			new SimpleType(),
+		];
+		yield [
+			new SentryIdentificator('integer'),
+			new SimpleType(),
+		];
+		yield [
+			new SentryIdentificator('boolean'),
+			new SimpleType(),
+		];
+		yield [
+			new SentryIdentificator('mixed'),
+			new SimpleType(),
+		];
+		yield [
+			new SentryIdentificator('DateTimeImmutable'),
+			new SimpleType(),
+		];
+		yield [
+			new SentryIdentificator('string[]'),
+			new CollectionType(),
+		];
+		yield [
+			new SentryIdentificator('int[]'),
+			new CollectionType(),
+		];
+		yield [
+			new SentryIdentificator('bool[]'),
+			new CollectionType(),
+		];
+		yield [
+			new SentryIdentificator('float[]'),
+			new CollectionType(),
+		];
+		yield [
+			new SentryIdentificator('integer[]'),
+			new CollectionType(),
+		];
+		yield [
+			new SentryIdentificator('boolean[]'),
+			new CollectionType(),
+		];
+		yield [
+			new SentryIdentificator('mixed[]'),
+			new CollectionType(),
+		];
+		yield [
+			new SentryIdentificator('DateTimeImmutable[]'),
+			new CollectionType(),
+		];
 	}
 
 	/**

--- a/tests/Factory/Simple/SimpleSentryFactoryTest.php
+++ b/tests/Factory/Simple/SimpleSentryFactoryTest.php
@@ -61,20 +61,27 @@ class SimpleSentryFactoryTest extends \PHPUnit\Framework\TestCase
 	public function testNoSentry(): void
 	{
 		$factory = new SimpleSentryFactory(new SentryIdentificatorParser());
+		$sentryIdentificator = new SentryIdentificator('');
 
-		$this->expectException(\Consistence\Sentry\Factory\NoSentryForIdentificatorException::class);
-
-		$factory->getSentry(new SentryIdentificator(''));
+		try {
+			$factory->getSentry($sentryIdentificator);
+			Assert::fail('Exception expected');
+		} catch (\Consistence\Sentry\Factory\NoSentryForIdentificatorException $e) {
+			Assert::assertSame($sentryIdentificator, $e->getSentryIdentificator());
+		}
 	}
 
 	public function testNonexistingObject(): void
 	{
 		$factory = new SimpleSentryFactory(new SentryIdentificatorParser());
+		$sentryIdentificator = new SentryIdentificator('Foo\Bar');
 
-		$this->expectException(\Consistence\Sentry\Factory\NoSentryForIdentificatorException::class);
-		$this->expectExceptionMessage('Foo\Bar');
-
-		$factory->getSentry(new SentryIdentificator('Foo\Bar'));
+		try {
+			$factory->getSentry($sentryIdentificator);
+			Assert::fail('Exception expected');
+		} catch (\Consistence\Sentry\Factory\NoSentryForIdentificatorException $e) {
+			Assert::assertSame($sentryIdentificator, $e->getSentryIdentificator());
+		}
 	}
 
 }

--- a/tests/Factory/Simple/SimpleSentryFactoryTest.php
+++ b/tests/Factory/Simple/SimpleSentryFactoryTest.php
@@ -105,23 +105,29 @@ class SimpleSentryFactoryTest extends \PHPUnit\Framework\TestCase
 		Assert::assertSame($sentry, $factory->getSentry(new SentryIdentificator('string')));
 	}
 
-	public function testNoSentry(): void
+	/**
+	 * @return mixed[][]|\Generator
+	 */
+	public function getSentryWhenNoSentryForIdentificatorDataProvider(): Generator
 	{
-		$factory = new SimpleSentryFactory(new SentryIdentificatorParser());
-		$sentryIdentificator = new SentryIdentificator('');
-
-		try {
-			$factory->getSentry($sentryIdentificator);
-			Assert::fail('Exception expected');
-		} catch (\Consistence\Sentry\Factory\NoSentryForIdentificatorException $e) {
-			Assert::assertSame($sentryIdentificator, $e->getSentryIdentificator());
-		}
+		yield 'empty string' => [
+			'sentryIdentificator' => new SentryIdentificator(''),
+		];
+		yield 'nonexistent object' => [
+			'sentryIdentificator' => new SentryIdentificator('Foo\Bar'),
+		];
 	}
 
-	public function testNonexistingObject(): void
+	/**
+	 * @dataProvider getSentryWhenNoSentryForIdentificatorDataProvider
+	 *
+	 * @param \Consistence\Sentry\Metadata\SentryIdentificator $sentryIdentificator
+	 */
+	public function testGetSentryWhenNoSentryForIdentificator(
+		SentryIdentificator $sentryIdentificator
+	): void
 	{
 		$factory = new SimpleSentryFactory(new SentryIdentificatorParser());
-		$sentryIdentificator = new SentryIdentificator('Foo\Bar');
 
 		try {
 			$factory->getSentry($sentryIdentificator);

--- a/tests/Factory/Simple/SimpleSentryFactoryTest.php
+++ b/tests/Factory/Simple/SimpleSentryFactoryTest.php
@@ -20,67 +20,67 @@ class SimpleSentryFactoryTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function sentryIdentificatorToSentryDataProvider(): Generator
 	{
-		yield [
+		yield 'string' => [
 			'sentryIdentificator' => new SentryIdentificator('string'),
 			'sentry' => new SimpleType(),
 		];
-		yield [
+		yield 'int' => [
 			'sentryIdentificator' => new SentryIdentificator('int'),
 			'sentry' => new SimpleType(),
 		];
-		yield [
+		yield 'bool' => [
 			'sentryIdentificator' => new SentryIdentificator('bool'),
 			'sentry' => new SimpleType(),
 		];
-		yield [
+		yield 'float' => [
 			'sentryIdentificator' => new SentryIdentificator('float'),
 			'sentry' => new SimpleType(),
 		];
-		yield [
+		yield 'integer' => [
 			'sentryIdentificator' => new SentryIdentificator('integer'),
 			'sentry' => new SimpleType(),
 		];
-		yield [
+		yield 'boolean' => [
 			'sentryIdentificator' => new SentryIdentificator('boolean'),
 			'sentry' => new SimpleType(),
 		];
-		yield [
+		yield 'mixed' => [
 			'sentryIdentificator' => new SentryIdentificator('mixed'),
 			'sentry' => new SimpleType(),
 		];
-		yield [
+		yield 'object' => [
 			'sentryIdentificator' => new SentryIdentificator('DateTimeImmutable'),
 			'sentry' => new SimpleType(),
 		];
-		yield [
+		yield 'string array' => [
 			'sentryIdentificator' => new SentryIdentificator('string[]'),
 			'sentry' => new CollectionType(),
 		];
-		yield [
+		yield 'int array' => [
 			'sentryIdentificator' => new SentryIdentificator('int[]'),
 			'sentry' => new CollectionType(),
 		];
-		yield [
+		yield 'bool array' => [
 			'sentryIdentificator' => new SentryIdentificator('bool[]'),
 			'sentry' => new CollectionType(),
 		];
-		yield [
+		yield 'float array' => [
 			'sentryIdentificator' => new SentryIdentificator('float[]'),
 			'sentry' => new CollectionType(),
 		];
-		yield [
+		yield 'integer array' => [
 			'sentryIdentificator' => new SentryIdentificator('integer[]'),
 			'sentry' => new CollectionType(),
 		];
-		yield [
+		yield 'boolean array' => [
 			'sentryIdentificator' => new SentryIdentificator('boolean[]'),
 			'sentry' => new CollectionType(),
 		];
-		yield [
+		yield 'mixed array' => [
 			'sentryIdentificator' => new SentryIdentificator('mixed[]'),
 			'sentry' => new CollectionType(),
 		];
-		yield [
+		yield 'object array' => [
 			'sentryIdentificator' => new SentryIdentificator('DateTimeImmutable[]'),
 			'sentry' => new CollectionType(),
 		];

--- a/tests/Factory/Simple/SimpleSentryFactoryTest.php
+++ b/tests/Factory/Simple/SimpleSentryFactoryTest.php
@@ -9,34 +9,33 @@ use Consistence\Sentry\SentryIdentificatorParser\SentryIdentificatorParser;
 use Consistence\Sentry\Type\CollectionType;
 use Consistence\Sentry\Type\Sentry;
 use Consistence\Sentry\Type\SimpleType;
+use Generator;
 use PHPUnit\Framework\Assert;
 
 class SimpleSentryFactoryTest extends \PHPUnit\Framework\TestCase
 {
 
 	/**
-	 * @return mixed[][]
+	 * @return mixed[][]|\Generator
 	 */
-	public function sentryIdentificatorToSentryDataProvider(): array
+	public function sentryIdentificatorToSentryDataProvider(): Generator
 	{
-		return [
-			[new SentryIdentificator('string'), new SimpleType()],
-			[new SentryIdentificator('int'), new SimpleType()],
-			[new SentryIdentificator('bool'), new SimpleType()],
-			[new SentryIdentificator('float'), new SimpleType()],
-			[new SentryIdentificator('integer'), new SimpleType()],
-			[new SentryIdentificator('boolean'), new SimpleType()],
-			[new SentryIdentificator('mixed'), new SimpleType()],
-			[new SentryIdentificator('DateTimeImmutable'), new SimpleType()],
-			[new SentryIdentificator('string[]'), new CollectionType()],
-			[new SentryIdentificator('int[]'), new CollectionType()],
-			[new SentryIdentificator('bool[]'), new CollectionType()],
-			[new SentryIdentificator('float[]'), new CollectionType()],
-			[new SentryIdentificator('integer[]'), new CollectionType()],
-			[new SentryIdentificator('boolean[]'), new CollectionType()],
-			[new SentryIdentificator('mixed[]'), new CollectionType()],
-			[new SentryIdentificator('DateTimeImmutable[]'), new CollectionType()],
-		];
+		yield [new SentryIdentificator('string'), new SimpleType()];
+		yield [new SentryIdentificator('int'), new SimpleType()];
+		yield [new SentryIdentificator('bool'), new SimpleType()];
+		yield [new SentryIdentificator('float'), new SimpleType()];
+		yield [new SentryIdentificator('integer'), new SimpleType()];
+		yield [new SentryIdentificator('boolean'), new SimpleType()];
+		yield [new SentryIdentificator('mixed'), new SimpleType()];
+		yield [new SentryIdentificator('DateTimeImmutable'), new SimpleType()];
+		yield [new SentryIdentificator('string[]'), new CollectionType()];
+		yield [new SentryIdentificator('int[]'), new CollectionType()];
+		yield [new SentryIdentificator('bool[]'), new CollectionType()];
+		yield [new SentryIdentificator('float[]'), new CollectionType()];
+		yield [new SentryIdentificator('integer[]'), new CollectionType()];
+		yield [new SentryIdentificator('boolean[]'), new CollectionType()];
+		yield [new SentryIdentificator('mixed[]'), new CollectionType()];
+		yield [new SentryIdentificator('DateTimeImmutable[]'), new CollectionType()];
 	}
 
 	/**

--- a/tests/Factory/Simple/SimpleSentryFactoryTest.php
+++ b/tests/Factory/Simple/SimpleSentryFactoryTest.php
@@ -9,6 +9,7 @@ use Consistence\Sentry\SentryIdentificatorParser\SentryIdentificatorParser;
 use Consistence\Sentry\Type\CollectionType;
 use Consistence\Sentry\Type\Sentry;
 use Consistence\Sentry\Type\SimpleType;
+use PHPUnit\Framework\Assert;
 
 class SimpleSentryFactoryTest extends \PHPUnit\Framework\TestCase
 {
@@ -47,14 +48,14 @@ class SimpleSentryFactoryTest extends \PHPUnit\Framework\TestCase
 	public function testGetSentry(SentryIdentificator $sentryIdentificator, Sentry $sentry): void
 	{
 		$factory = new SimpleSentryFactory(new SentryIdentificatorParser());
-		$this->assertTrue($factory->getSentry($sentryIdentificator) instanceof $sentry);
+		Assert::assertTrue($factory->getSentry($sentryIdentificator) instanceof $sentry);
 	}
 
 	public function testSameSentryInstance(): void
 	{
 		$factory = new SimpleSentryFactory(new SentryIdentificatorParser());
 		$sentry = $factory->getSentry(new SentryIdentificator('string'));
-		$this->assertSame($sentry, $factory->getSentry(new SentryIdentificator('string')));
+		Assert::assertSame($sentry, $factory->getSentry(new SentryIdentificator('string')));
 	}
 
 	public function testNoSentry(): void

--- a/tests/Factory/Simple/SimpleSentryFactoryTest.php
+++ b/tests/Factory/Simple/SimpleSentryFactoryTest.php
@@ -17,7 +17,7 @@ class SimpleSentryFactoryTest extends \PHPUnit\Framework\TestCase
 	/**
 	 * @return mixed[][]
 	 */
-	public function sentryIdentificatorToSentryProvider(): array
+	public function sentryIdentificatorToSentryDataProvider(): array
 	{
 		return [
 			[new SentryIdentificator('string'), new SimpleType()],
@@ -40,7 +40,7 @@ class SimpleSentryFactoryTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider sentryIdentificatorToSentryProvider
+	 * @dataProvider sentryIdentificatorToSentryDataProvider
 	 *
 	 * @param \Consistence\Sentry\Metadata\SentryIdentificator $sentryIdentificator
 	 * @param \Consistence\Sentry\Type\Sentry $sentry

--- a/tests/Factory/Simple/SimpleSentryFactoryTest.php
+++ b/tests/Factory/Simple/SimpleSentryFactoryTest.php
@@ -21,68 +21,68 @@ class SimpleSentryFactoryTest extends \PHPUnit\Framework\TestCase
 	public function sentryIdentificatorToSentryDataProvider(): Generator
 	{
 		yield [
-			new SentryIdentificator('string'),
-			new SimpleType(),
+			'sentryIdentificator' => new SentryIdentificator('string'),
+			'sentry' => new SimpleType(),
 		];
 		yield [
-			new SentryIdentificator('int'),
-			new SimpleType(),
+			'sentryIdentificator' => new SentryIdentificator('int'),
+			'sentry' => new SimpleType(),
 		];
 		yield [
-			new SentryIdentificator('bool'),
-			new SimpleType(),
+			'sentryIdentificator' => new SentryIdentificator('bool'),
+			'sentry' => new SimpleType(),
 		];
 		yield [
-			new SentryIdentificator('float'),
-			new SimpleType(),
+			'sentryIdentificator' => new SentryIdentificator('float'),
+			'sentry' => new SimpleType(),
 		];
 		yield [
-			new SentryIdentificator('integer'),
-			new SimpleType(),
+			'sentryIdentificator' => new SentryIdentificator('integer'),
+			'sentry' => new SimpleType(),
 		];
 		yield [
-			new SentryIdentificator('boolean'),
-			new SimpleType(),
+			'sentryIdentificator' => new SentryIdentificator('boolean'),
+			'sentry' => new SimpleType(),
 		];
 		yield [
-			new SentryIdentificator('mixed'),
-			new SimpleType(),
+			'sentryIdentificator' => new SentryIdentificator('mixed'),
+			'sentry' => new SimpleType(),
 		];
 		yield [
-			new SentryIdentificator('DateTimeImmutable'),
-			new SimpleType(),
+			'sentryIdentificator' => new SentryIdentificator('DateTimeImmutable'),
+			'sentry' => new SimpleType(),
 		];
 		yield [
-			new SentryIdentificator('string[]'),
-			new CollectionType(),
+			'sentryIdentificator' => new SentryIdentificator('string[]'),
+			'sentry' => new CollectionType(),
 		];
 		yield [
-			new SentryIdentificator('int[]'),
-			new CollectionType(),
+			'sentryIdentificator' => new SentryIdentificator('int[]'),
+			'sentry' => new CollectionType(),
 		];
 		yield [
-			new SentryIdentificator('bool[]'),
-			new CollectionType(),
+			'sentryIdentificator' => new SentryIdentificator('bool[]'),
+			'sentry' => new CollectionType(),
 		];
 		yield [
-			new SentryIdentificator('float[]'),
-			new CollectionType(),
+			'sentryIdentificator' => new SentryIdentificator('float[]'),
+			'sentry' => new CollectionType(),
 		];
 		yield [
-			new SentryIdentificator('integer[]'),
-			new CollectionType(),
+			'sentryIdentificator' => new SentryIdentificator('integer[]'),
+			'sentry' => new CollectionType(),
 		];
 		yield [
-			new SentryIdentificator('boolean[]'),
-			new CollectionType(),
+			'sentryIdentificator' => new SentryIdentificator('boolean[]'),
+			'sentry' => new CollectionType(),
 		];
 		yield [
-			new SentryIdentificator('mixed[]'),
-			new CollectionType(),
+			'sentryIdentificator' => new SentryIdentificator('mixed[]'),
+			'sentry' => new CollectionType(),
 		];
 		yield [
-			new SentryIdentificator('DateTimeImmutable[]'),
-			new CollectionType(),
+			'sentryIdentificator' => new SentryIdentificator('DateTimeImmutable[]'),
+			'sentry' => new CollectionType(),
 		];
 	}
 

--- a/tests/Generated/SentryAutoloaderTest.php
+++ b/tests/Generated/SentryAutoloaderTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Consistence\Sentry\Generated;
 
+use PHPUnit\Framework\Assert;
 use org\bovigo\vfs\vfsStream;
 
 class SentryAutoloaderTest extends \PHPUnit\Framework\TestCase
@@ -21,19 +22,19 @@ class SentryAutoloaderTest extends \PHPUnit\Framework\TestCase
 
 		$generator = $this->createMock(SentryGenerator::class);
 		$generator
-			->expects($this->once())
+			->expects(self::once())
 			->method('generateAll')
-			->will($this->returnValue($classMap));
+			->will(self::returnValue($classMap));
 
 		$autoloader = new SentryAutoloader($generator, $targetPath);
 
-		$this->assertFalse($autoloader->isClassMapReady());
+		Assert::assertFalse($autoloader->isClassMapReady());
 
 		$autoloader->rebuild();
 
-		$this->assertTrue($autoloader->isClassMapReady());
+		Assert::assertTrue($autoloader->isClassMapReady());
 
-		$this->assertEquals($classMap, require $targetPath);
+		Assert::assertEquals($classMap, require $targetPath);
 	}
 
 }

--- a/tests/Generated/SentryGeneratorTest.php
+++ b/tests/Generated/SentryGeneratorTest.php
@@ -134,7 +134,7 @@ class SentryGeneratorTest extends \PHPUnit\Framework\TestCase
 
 		try {
 			$generator->generateClass($classReflection);
-			Assert::fail();
+			Assert::fail('Exception expected');
 		} catch (\Consistence\Sentry\Generated\NoMethodsToBeGeneratedException $e) {
 			Assert::assertSame($classMetadata, $e->getClassMetadata());
 		}
@@ -175,7 +175,7 @@ class SentryGeneratorTest extends \PHPUnit\Framework\TestCase
 
 		try {
 			$generator->generateClass($classReflection);
-			Assert::fail();
+			Assert::fail('Exception expected');
 		} catch (\Consistence\Sentry\Generated\NoMethodsToBeGeneratedException $e) {
 			Assert::assertSame($classMetadata, $e->getClassMetadata());
 		}

--- a/tests/Generated/SentryGeneratorTest.php
+++ b/tests/Generated/SentryGeneratorTest.php
@@ -12,6 +12,7 @@ use Consistence\Sentry\Metadata\SentryIdentificator;
 use Consistence\Sentry\Metadata\SentryMethod;
 use Consistence\Sentry\MetadataSource\MetadataSource;
 use Consistence\Sentry\Type\Sentry;
+use PHPUnit\Framework\Assert;
 use ReflectionClass;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\visitor\vfsStreamStructureVisitor;
@@ -33,40 +34,40 @@ class SentryGeneratorTest extends \PHPUnit\Framework\TestCase
 
 		$fooProperty = $this->createMock(PropertyMetadata::class);
 		$fooProperty
-			->expects($this->once())
+			->expects(self::once())
 			->method('getSentryIdentificator')
-			->will($this->returnValue($sentryIdentificator));
+			->will(self::returnValue($sentryIdentificator));
 		$fooProperty
-			->expects($this->once())
+			->expects(self::once())
 			->method('getSentryMethods')
-			->will($this->returnValue([$fooMethod]));
+			->will(self::returnValue([$fooMethod]));
 
 		$classMetadata = $this->createMock(ClassMetadata::class);
 		$classMetadata
-			->expects($this->once())
+			->expects(self::once())
 			->method('getProperties')
-			->will($this->returnValue([$fooProperty]));
+			->will(self::returnValue([$fooProperty]));
 
 		$metadataSource = $this->createMock(MetadataSource::class);
 		$metadataSource
-			->expects($this->once())
+			->expects(self::once())
 			->method('getMetadataForClass')
 			->with($classReflection)
-			->will($this->returnValue($classMetadata));
+			->will(self::returnValue($classMetadata));
 
 		$sentry = $this->createMock(Sentry::class);
 		$sentry
-			->expects($this->once())
+			->expects(self::once())
 			->method('generateMethod')
-			->with($this->identicalTo($fooProperty), $this->identicalTo($fooMethod))
-			->will($this->returnValue('function test() {}'));
+			->with(Assert::identicalTo($fooProperty), Assert::identicalTo($fooMethod))
+			->will(self::returnValue('function test() {}'));
 
 		$sentryFactory = $this->createMock(SentryFactory::class);
 		$sentryFactory
-			->expects($this->once())
+			->expects(self::once())
 			->method('getSentry')
-			->with($this->identicalTo($sentryIdentificator))
-			->will($this->returnValue($sentry));
+			->with(Assert::identicalTo($sentryIdentificator))
+			->will(self::returnValue($sentry));
 
 		$generator = new SentryGenerator(
 			$classFinder,
@@ -76,7 +77,7 @@ class SentryGeneratorTest extends \PHPUnit\Framework\TestCase
 		);
 
 		$fileName = $generator->generateClass($classReflection);
-		$this->assertFileExists($fileName);
+		Assert::assertFileExists($fileName);
 	}
 
 	public function testGenerateClassSkipMethodNameCaseInsensitive(): void
@@ -91,38 +92,38 @@ class SentryGeneratorTest extends \PHPUnit\Framework\TestCase
 
 		$fooMethod = $this->createMock(SentryMethod::class);
 		$fooMethod
-			->expects($this->once())
+			->expects(self::once())
 			->method('getMethodName')
-			->will($this->returnValue('GETskipPROPERTY'));
+			->will(self::returnValue('GETskipPROPERTY'));
 
 		$fooProperty = $this->createMock(PropertyMetadata::class);
 		$fooProperty
-			->expects($this->once())
+			->expects(self::once())
 			->method('getSentryIdentificator')
-			->will($this->returnValue($sentryIdentificator));
+			->will(self::returnValue($sentryIdentificator));
 		$fooProperty
-			->expects($this->once())
+			->expects(self::once())
 			->method('getSentryMethods')
-			->will($this->returnValue([$fooMethod]));
+			->will(self::returnValue([$fooMethod]));
 
 		$classMetadata = $this->createMock(ClassMetadata::class);
 		$classMetadata
-			->expects($this->once())
+			->expects(self::once())
 			->method('getProperties')
-			->will($this->returnValue([$fooProperty]));
+			->will(self::returnValue([$fooProperty]));
 
 		$metadataSource = $this->createMock(MetadataSource::class);
 		$metadataSource
-			->expects($this->once())
+			->expects(self::once())
 			->method('getMetadataForClass')
 			->with($classReflection)
-			->will($this->returnValue($classMetadata));
+			->will(self::returnValue($classMetadata));
 
 		$sentryFactory = $this->createMock(SentryFactory::class);
 		$sentryFactory
-			->expects($this->once())
+			->expects(self::once())
 			->method('getSentry')
-			->with($this->identicalTo($sentryIdentificator));
+			->with(Assert::identicalTo($sentryIdentificator));
 
 		$generator = new SentryGenerator(
 			$classFinder,
@@ -133,9 +134,9 @@ class SentryGeneratorTest extends \PHPUnit\Framework\TestCase
 
 		try {
 			$generator->generateClass($classReflection);
-			$this->fail();
+			Assert::fail();
 		} catch (\Consistence\Sentry\Generated\NoMethodsToBeGeneratedException $e) {
-			$this->assertSame($classMetadata, $e->getClassMetadata());
+			Assert::assertSame($classMetadata, $e->getClassMetadata());
 		}
 	}
 
@@ -149,20 +150,20 @@ class SentryGeneratorTest extends \PHPUnit\Framework\TestCase
 
 		$classMetadata = $this->createMock(ClassMetadata::class);
 		$classMetadata
-			->expects($this->once())
+			->expects(self::once())
 			->method('getProperties')
-			->will($this->returnValue([]));
+			->will(self::returnValue([]));
 
 		$metadataSource = $this->createMock(MetadataSource::class);
 		$metadataSource
-			->expects($this->once())
+			->expects(self::once())
 			->method('getMetadataForClass')
 			->with($classReflection)
-			->will($this->returnValue($classMetadata));
+			->will(self::returnValue($classMetadata));
 
 		$sentryFactory = $this->createMock(SentryFactory::class);
 		$sentryFactory
-			->expects($this->never())
+			->expects(self::never())
 			->method('getSentry');
 
 		$generator = new SentryGenerator(
@@ -174,9 +175,9 @@ class SentryGeneratorTest extends \PHPUnit\Framework\TestCase
 
 		try {
 			$generator->generateClass($classReflection);
-			$this->fail();
+			Assert::fail();
 		} catch (\Consistence\Sentry\Generated\NoMethodsToBeGeneratedException $e) {
-			$this->assertSame($classMetadata, $e->getClassMetadata());
+			Assert::assertSame($classMetadata, $e->getClassMetadata());
 		}
 	}
 
@@ -188,9 +189,9 @@ class SentryGeneratorTest extends \PHPUnit\Framework\TestCase
 
 		$classFinder = $this->createMock(ClassFinder::class);
 		$classFinder
-			->expects($this->once())
+			->expects(self::once())
 			->method('findByInterface')
-			->will($this->returnValue([FooClass::class]));
+			->will(self::returnValue([FooClass::class]));
 
 		$sentryIdentificator = new SentryIdentificator('string');
 
@@ -198,40 +199,40 @@ class SentryGeneratorTest extends \PHPUnit\Framework\TestCase
 
 		$fooProperty = $this->createMock(PropertyMetadata::class);
 		$fooProperty
-			->expects($this->once())
+			->expects(self::once())
 			->method('getSentryIdentificator')
-			->will($this->returnValue($sentryIdentificator));
+			->will(self::returnValue($sentryIdentificator));
 		$fooProperty
-			->expects($this->once())
+			->expects(self::once())
 			->method('getSentryMethods')
-			->will($this->returnValue([$fooMethod]));
+			->will(self::returnValue([$fooMethod]));
 
 		$classMetadata = $this->createMock(ClassMetadata::class);
 		$classMetadata
-			->expects($this->once())
+			->expects(self::once())
 			->method('getProperties')
-			->will($this->returnValue([$fooProperty]));
+			->will(self::returnValue([$fooProperty]));
 
 		$metadataSource = $this->createMock(MetadataSource::class);
 		$metadataSource
-			->expects($this->once())
+			->expects(self::once())
 			->method('getMetadataForClass')
 			->with($classReflection)
-			->will($this->returnValue($classMetadata));
+			->will(self::returnValue($classMetadata));
 
 		$sentry = $this->createMock(Sentry::class);
 		$sentry
-			->expects($this->once())
+			->expects(self::once())
 			->method('generateMethod')
-			->with($this->identicalTo($fooProperty), $this->identicalTo($fooMethod))
-			->will($this->returnValue('function test() {}'));
+			->with(Assert::identicalTo($fooProperty), Assert::identicalTo($fooMethod))
+			->will(self::returnValue('function test() {}'));
 
 		$sentryFactory = $this->createMock(SentryFactory::class);
 		$sentryFactory
-			->expects($this->once())
+			->expects(self::once())
 			->method('getSentry')
-			->with($this->identicalTo($sentryIdentificator))
-			->will($this->returnValue($sentry));
+			->with(Assert::identicalTo($sentryIdentificator))
+			->will(self::returnValue($sentry));
 
 		$generator = new SentryGenerator(
 			$classFinder,
@@ -241,11 +242,11 @@ class SentryGeneratorTest extends \PHPUnit\Framework\TestCase
 		);
 
 		$generated = $generator->generateAll();
-		$this->assertCount(1, $generated);
+		Assert::assertCount(1, $generated);
 
 		$structure = vfsStream::inspect(new vfsStreamStructureVisitor())->getStructure();
-		$this->assertCount(1, $structure['sentry']);
-		$this->assertTrue(isset($structure['sentry']['Consistence_Sentry_Generated_FooClass.php']));
+		Assert::assertCount(1, $structure['sentry']);
+		Assert::assertTrue(isset($structure['sentry']['Consistence_Sentry_Generated_FooClass.php']));
 	}
 
 	public function testGenerateAllNoMethods(): void
@@ -256,26 +257,26 @@ class SentryGeneratorTest extends \PHPUnit\Framework\TestCase
 
 		$classFinder = $this->createMock(ClassFinder::class);
 		$classFinder
-			->expects($this->once())
+			->expects(self::once())
 			->method('findByInterface')
-			->will($this->returnValue([FooClass::class]));
+			->will(self::returnValue([FooClass::class]));
 
 		$classMetadata = $this->createMock(ClassMetadata::class);
 		$classMetadata
-			->expects($this->once())
+			->expects(self::once())
 			->method('getProperties')
-			->will($this->returnValue([]));
+			->will(self::returnValue([]));
 
 		$metadataSource = $this->createMock(MetadataSource::class);
 		$metadataSource
-			->expects($this->once())
+			->expects(self::once())
 			->method('getMetadataForClass')
 			->with($classReflection)
-			->will($this->returnValue($classMetadata));
+			->will(self::returnValue($classMetadata));
 
 		$sentryFactory = $this->createMock(SentryFactory::class);
 		$sentryFactory
-			->expects($this->never())
+			->expects(self::never())
 			->method('getSentry');
 
 		$generator = new SentryGenerator(
@@ -286,10 +287,10 @@ class SentryGeneratorTest extends \PHPUnit\Framework\TestCase
 		);
 
 		$generated = $generator->generateAll();
-		$this->assertCount(0, $generated);
+		Assert::assertCount(0, $generated);
 
 		$structure = vfsStream::inspect(new vfsStreamStructureVisitor())->getStructure();
-		$this->assertCount(0, $structure['sentry']);
+		Assert::assertCount(0, $structure['sentry']);
 	}
 
 }

--- a/tests/Metadata/BidirectionalAssociationTest.php
+++ b/tests/Metadata/BidirectionalAssociationTest.php
@@ -106,7 +106,7 @@ class BidirectionalAssociationTest extends \PHPUnit\Framework\TestCase
 				new SentryAccess('set'),
 				Visibility::get(Visibility::VISIBILITY_PUBLIC)
 			);
-			Assert::fail();
+			Assert::fail('Exception expected');
 		} catch (\Consistence\Sentry\Metadata\NoSuitableMethodException $e) {
 			Assert::assertSame('FooClass', $e->getClassName());
 			Assert::assertSame('fooProperty', $e->getPropertyName());

--- a/tests/Metadata/BidirectionalAssociationTest.php
+++ b/tests/Metadata/BidirectionalAssociationTest.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace Consistence\Sentry\Metadata;
 
+use PHPUnit\Framework\Assert;
+
 class BidirectionalAssociationTest extends \PHPUnit\Framework\TestCase
 {
 
@@ -23,9 +25,9 @@ class BidirectionalAssociationTest extends \PHPUnit\Framework\TestCase
 			$sentryMethods
 		);
 
-		$this->assertSame('FooClass', $bidirectionalAssociation->getTargetClass());
-		$this->assertSame('fooProperty', $bidirectionalAssociation->getTargetProperty());
-		$this->assertTrue($bidirectionalAssociation->getTargetType()->equalsValue(BidirectionalAssociationType::ONE));
+		Assert::assertSame('FooClass', $bidirectionalAssociation->getTargetClass());
+		Assert::assertSame('fooProperty', $bidirectionalAssociation->getTargetProperty());
+		Assert::assertTrue($bidirectionalAssociation->getTargetType()->equalsValue(BidirectionalAssociationType::ONE));
 	}
 
 	public function testGetTargetMethodForType(): void
@@ -53,9 +55,9 @@ class BidirectionalAssociationTest extends \PHPUnit\Framework\TestCase
 			new SentryAccess('set'),
 			Visibility::get(Visibility::VISIBILITY_PUBLIC)
 		);
-		$this->assertSame('setFoo', $targetMethod->getMethodName());
-		$this->assertTrue($targetMethod->getMethodVisibility()->equalsValue(Visibility::VISIBILITY_PUBLIC));
-		$this->assertTrue($targetMethod->getSentryAccess()->equals(new SentryAccess('set')));
+		Assert::assertSame('setFoo', $targetMethod->getMethodName());
+		Assert::assertTrue($targetMethod->getMethodVisibility()->equalsValue(Visibility::VISIBILITY_PUBLIC));
+		Assert::assertTrue($targetMethod->getSentryAccess()->equals(new SentryAccess('set')));
 	}
 
 	public function testGetTargetMethodForTypeLooserVisibility(): void
@@ -78,9 +80,9 @@ class BidirectionalAssociationTest extends \PHPUnit\Framework\TestCase
 			new SentryAccess('set'),
 			Visibility::get(Visibility::VISIBILITY_PRIVATE)
 		);
-		$this->assertSame('setFoo', $targetMethod->getMethodName());
-		$this->assertTrue($targetMethod->getMethodVisibility()->equalsValue(Visibility::VISIBILITY_PUBLIC));
-		$this->assertTrue($targetMethod->getSentryAccess()->equals(new SentryAccess('set')));
+		Assert::assertSame('setFoo', $targetMethod->getMethodName());
+		Assert::assertTrue($targetMethod->getMethodVisibility()->equalsValue(Visibility::VISIBILITY_PUBLIC));
+		Assert::assertTrue($targetMethod->getSentryAccess()->equals(new SentryAccess('set')));
 	}
 
 	public function testGetTargetMethodForTypeRequiredVisibilityNotFound(): void
@@ -104,11 +106,11 @@ class BidirectionalAssociationTest extends \PHPUnit\Framework\TestCase
 				new SentryAccess('set'),
 				Visibility::get(Visibility::VISIBILITY_PUBLIC)
 			);
-			$this->fail();
+			Assert::fail();
 		} catch (\Consistence\Sentry\Metadata\NoSuitableMethodException $e) {
-			$this->assertSame('FooClass', $e->getClassName());
-			$this->assertSame('fooProperty', $e->getPropertyName());
-			$this->assertTrue($e->getSentryAccess()->equals(new SentryAccess('set')));
+			Assert::assertSame('FooClass', $e->getClassName());
+			Assert::assertSame('fooProperty', $e->getPropertyName());
+			Assert::assertTrue($e->getSentryAccess()->equals(new SentryAccess('set')));
 		}
 	}
 
@@ -137,9 +139,9 @@ class BidirectionalAssociationTest extends \PHPUnit\Framework\TestCase
 			new SentryAccess('set'),
 			Visibility::get(Visibility::VISIBILITY_PUBLIC)
 		);
-		$this->assertSame('setPublic', $targetMethod->getMethodName());
-		$this->assertTrue($targetMethod->getMethodVisibility()->equalsValue(Visibility::VISIBILITY_PUBLIC));
-		$this->assertTrue($targetMethod->getSentryAccess()->equals(new SentryAccess('set')));
+		Assert::assertSame('setPublic', $targetMethod->getMethodName());
+		Assert::assertTrue($targetMethod->getMethodVisibility()->equalsValue(Visibility::VISIBILITY_PUBLIC));
+		Assert::assertTrue($targetMethod->getSentryAccess()->equals(new SentryAccess('set')));
 	}
 
 	public function testGetTargetMethodForTypeMultipleSentryAccessPickByOrder(): void
@@ -167,9 +169,9 @@ class BidirectionalAssociationTest extends \PHPUnit\Framework\TestCase
 			new SentryAccess('set'),
 			Visibility::get(Visibility::VISIBILITY_PUBLIC)
 		);
-		$this->assertSame('setFirst', $targetMethod->getMethodName());
-		$this->assertTrue($targetMethod->getMethodVisibility()->equalsValue(Visibility::VISIBILITY_PUBLIC));
-		$this->assertTrue($targetMethod->getSentryAccess()->equals(new SentryAccess('set')));
+		Assert::assertSame('setFirst', $targetMethod->getMethodName());
+		Assert::assertTrue($targetMethod->getMethodVisibility()->equalsValue(Visibility::VISIBILITY_PUBLIC));
+		Assert::assertTrue($targetMethod->getSentryAccess()->equals(new SentryAccess('set')));
 	}
 
 }

--- a/tests/Metadata/BidirectionalAssociationTest.php
+++ b/tests/Metadata/BidirectionalAssociationTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Consistence\Sentry\Metadata;
 
+use Generator;
 use PHPUnit\Framework\Assert;
 
 class BidirectionalAssociationTest extends \PHPUnit\Framework\TestCase
@@ -30,45 +31,88 @@ class BidirectionalAssociationTest extends \PHPUnit\Framework\TestCase
 		Assert::assertTrue($bidirectionalAssociation->getTargetType()->equalsValue(BidirectionalAssociationType::ONE));
 	}
 
-	public function testGetTargetMethodForType(): void
+	/**
+	 * @return mixed[][]|\Generator
+	 */
+	public function getTargetMethodForTypeDataProvider(): Generator
 	{
-		$sentryMethods = [
-			new SentryMethod(
-				new SentryAccess('get'),
-				'getFoo',
-				Visibility::get(Visibility::VISIBILITY_PUBLIC)
-			),
-			new SentryMethod(
-				new SentryAccess('set'),
-				'setFoo',
-				Visibility::get(Visibility::VISIBILITY_PUBLIC)
-			),
+		yield 'two public methods with different SentryAccess type' => [
+			'sentryMethods' => [
+				new SentryMethod(
+					new SentryAccess('get'),
+					'getFoo',
+					Visibility::get(Visibility::VISIBILITY_PUBLIC)
+				),
+				new SentryMethod(
+					new SentryAccess('set'),
+					'setFoo',
+					Visibility::get(Visibility::VISIBILITY_PUBLIC)
+				),
+			],
+			'visibility' => Visibility::get(Visibility::VISIBILITY_PUBLIC),
+			'expectedMethodName' => 'setFoo',
 		];
-		$bidirectionalAssociation = new BidirectionalAssociation(
-			'FooClass',
-			'fooProperty',
-			BidirectionalAssociationType::get(BidirectionalAssociationType::ONE),
-			$sentryMethods
-		);
 
-		$targetMethod = $bidirectionalAssociation->getTargetMethodForType(
-			new SentryAccess('set'),
-			Visibility::get(Visibility::VISIBILITY_PUBLIC)
-		);
-		Assert::assertSame('setFoo', $targetMethod->getMethodName());
-		Assert::assertTrue($targetMethod->getMethodVisibility()->equalsValue(Visibility::VISIBILITY_PUBLIC));
-		Assert::assertTrue($targetMethod->getSentryAccess()->equals(new SentryAccess('set')));
+		yield 'single public method, looser visibility' => [
+			'sentryMethods' => [
+				new SentryMethod(
+					new SentryAccess('set'),
+					'setFoo',
+					Visibility::get(Visibility::VISIBILITY_PUBLIC)
+				),
+			],
+			'visibility' => Visibility::get(Visibility::VISIBILITY_PRIVATE),
+			'expectedMethodName' => 'setFoo',
+		];
+
+		yield 'one public and one private method with same SentryAccess type, pick by visibility' => [
+			'sentryMethods' => [
+				new SentryMethod(
+					new SentryAccess('set'),
+					'setPrivate',
+					Visibility::get(Visibility::VISIBILITY_PRIVATE)
+				),
+				new SentryMethod(
+					new SentryAccess('set'),
+					'setPublic',
+					Visibility::get(Visibility::VISIBILITY_PUBLIC)
+				),
+			],
+			'visibility' => Visibility::get(Visibility::VISIBILITY_PUBLIC),
+			'expectedMethodName' => 'setPublic',
+		];
+
+		yield 'two public methods with same SentryAccess type, pick by order' => [
+			'sentryMethods' => [
+				new SentryMethod(
+					new SentryAccess('set'),
+					'setFirst',
+					Visibility::get(Visibility::VISIBILITY_PUBLIC)
+				),
+				new SentryMethod(
+					new SentryAccess('set'),
+					'setSecond',
+					Visibility::get(Visibility::VISIBILITY_PUBLIC)
+				),
+			],
+			'visibility' => Visibility::get(Visibility::VISIBILITY_PUBLIC),
+			'expectedMethodName' => 'setFirst',
+		];
 	}
 
-	public function testGetTargetMethodForTypeLooserVisibility(): void
+	/**
+	 * @dataProvider getTargetMethodForTypeDataProvider
+	 *
+	 * @param \Consistence\Sentry\Metadata\SentryMethod[] $sentryMethods
+	 * @param \Consistence\Sentry\Metadata\Visibility $visibility
+	 * @param string $expectedMethodName
+	 */
+	public function testGetTargetMethodForType(
+		array $sentryMethods,
+		Visibility $visibility,
+		string $expectedMethodName
+	): void
 	{
-		$sentryMethods = [
-			new SentryMethod(
-				new SentryAccess('set'),
-				'setFoo',
-				Visibility::get(Visibility::VISIBILITY_PUBLIC)
-			),
-		];
 		$bidirectionalAssociation = new BidirectionalAssociation(
 			'FooClass',
 			'fooProperty',
@@ -78,9 +122,9 @@ class BidirectionalAssociationTest extends \PHPUnit\Framework\TestCase
 
 		$targetMethod = $bidirectionalAssociation->getTargetMethodForType(
 			new SentryAccess('set'),
-			Visibility::get(Visibility::VISIBILITY_PRIVATE)
+			$visibility
 		);
-		Assert::assertSame('setFoo', $targetMethod->getMethodName());
+		Assert::assertSame($expectedMethodName, $targetMethod->getMethodName());
 		Assert::assertTrue($targetMethod->getMethodVisibility()->equalsValue(Visibility::VISIBILITY_PUBLIC));
 		Assert::assertTrue($targetMethod->getSentryAccess()->equals(new SentryAccess('set')));
 	}
@@ -112,66 +156,6 @@ class BidirectionalAssociationTest extends \PHPUnit\Framework\TestCase
 			Assert::assertSame('fooProperty', $e->getPropertyName());
 			Assert::assertTrue($e->getSentryAccess()->equals(new SentryAccess('set')));
 		}
-	}
-
-	public function testGetTargetMethodForTypePickByVisibility(): void
-	{
-		$sentryMethods = [
-			new SentryMethod(
-				new SentryAccess('set'),
-				'setPrivate',
-				Visibility::get(Visibility::VISIBILITY_PRIVATE)
-			),
-			new SentryMethod(
-				new SentryAccess('set'),
-				'setPublic',
-				Visibility::get(Visibility::VISIBILITY_PUBLIC)
-			),
-		];
-		$bidirectionalAssociation = new BidirectionalAssociation(
-			'FooClass',
-			'fooProperty',
-			BidirectionalAssociationType::get(BidirectionalAssociationType::ONE),
-			$sentryMethods
-		);
-
-		$targetMethod = $bidirectionalAssociation->getTargetMethodForType(
-			new SentryAccess('set'),
-			Visibility::get(Visibility::VISIBILITY_PUBLIC)
-		);
-		Assert::assertSame('setPublic', $targetMethod->getMethodName());
-		Assert::assertTrue($targetMethod->getMethodVisibility()->equalsValue(Visibility::VISIBILITY_PUBLIC));
-		Assert::assertTrue($targetMethod->getSentryAccess()->equals(new SentryAccess('set')));
-	}
-
-	public function testGetTargetMethodForTypeMultipleSentryAccessPickByOrder(): void
-	{
-		$sentryMethods = [
-			new SentryMethod(
-				new SentryAccess('set'),
-				'setFirst',
-				Visibility::get(Visibility::VISIBILITY_PUBLIC)
-			),
-			new SentryMethod(
-				new SentryAccess('set'),
-				'setSecond',
-				Visibility::get(Visibility::VISIBILITY_PUBLIC)
-			),
-		];
-		$bidirectionalAssociation = new BidirectionalAssociation(
-			'FooClass',
-			'fooProperty',
-			BidirectionalAssociationType::get(BidirectionalAssociationType::ONE),
-			$sentryMethods
-		);
-
-		$targetMethod = $bidirectionalAssociation->getTargetMethodForType(
-			new SentryAccess('set'),
-			Visibility::get(Visibility::VISIBILITY_PUBLIC)
-		);
-		Assert::assertSame('setFirst', $targetMethod->getMethodName());
-		Assert::assertTrue($targetMethod->getMethodVisibility()->equalsValue(Visibility::VISIBILITY_PUBLIC));
-		Assert::assertTrue($targetMethod->getSentryAccess()->equals(new SentryAccess('set')));
 	}
 
 }

--- a/tests/Metadata/ClassMetadataTest.php
+++ b/tests/Metadata/ClassMetadataTest.php
@@ -83,7 +83,7 @@ class ClassMetadataTest extends \PHPUnit\Framework\TestCase
 				'fooMethod',
 				Visibility::get(Visibility::VISIBILITY_PUBLIC)
 			);
-			Assert::fail();
+			Assert::fail('Exception expected');
 		} catch (\Consistence\Sentry\Metadata\MethodNotFoundException $e) {
 			Assert::assertSame('FooClass', $e->getClassName());
 			Assert::assertSame('fooMethod', $e->getMethodName());
@@ -116,7 +116,7 @@ class ClassMetadataTest extends \PHPUnit\Framework\TestCase
 
 		try {
 			$classMetadata->getPropertyByName($propertyName);
-			Assert::fail();
+			Assert::fail('Exception expected');
 		} catch (\Consistence\Sentry\Metadata\PropertyNotFoundException $e) {
 			Assert::assertSame($className, $e->getClassName());
 			Assert::assertSame($propertyName, $e->getPropertyName());

--- a/tests/Metadata/ClassMetadataTest.php
+++ b/tests/Metadata/ClassMetadataTest.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace Consistence\Sentry\Metadata;
 
+use PHPUnit\Framework\Assert;
+
 class ClassMetadataTest extends \PHPUnit\Framework\TestCase
 {
 
@@ -25,8 +27,8 @@ class ClassMetadataTest extends \PHPUnit\Framework\TestCase
 			'FooClass',
 			$properties
 		);
-		$this->assertSame('FooClass', $classMetadata->getName());
-		$this->assertSame($properties, $classMetadata->getProperties());
+		Assert::assertSame('FooClass', $classMetadata->getName());
+		Assert::assertSame($properties, $classMetadata->getProperties());
 	}
 
 	public function testGetSentryMethodByNameAndRequiredVisibility(): void
@@ -55,9 +57,9 @@ class ClassMetadataTest extends \PHPUnit\Framework\TestCase
 			'fooMethod',
 			Visibility::get(Visibility::VISIBILITY_PRIVATE)
 		);
-		$this->assertInstanceOf(SentryMethodSearchResult::class, $searchResult);
-		$this->assertSame($fooProperty, $searchResult->getProperty());
-		$this->assertSame($fooMethod, $searchResult->getSentryMethod());
+		Assert::assertInstanceOf(SentryMethodSearchResult::class, $searchResult);
+		Assert::assertSame($fooProperty, $searchResult->getProperty());
+		Assert::assertSame($fooMethod, $searchResult->getSentryMethod());
 	}
 
 	public function testGetSentryMethodByNameAndRequiredVisibilityMethodNotFound(): void
@@ -81,10 +83,10 @@ class ClassMetadataTest extends \PHPUnit\Framework\TestCase
 				'fooMethod',
 				Visibility::get(Visibility::VISIBILITY_PUBLIC)
 			);
-			$this->fail();
+			Assert::fail();
 		} catch (\Consistence\Sentry\Metadata\MethodNotFoundException $e) {
-			$this->assertSame('FooClass', $e->getClassName());
-			$this->assertSame('fooMethod', $e->getMethodName());
+			Assert::assertSame('FooClass', $e->getClassName());
+			Assert::assertSame('fooMethod', $e->getMethodName());
 		}
 	}
 
@@ -103,7 +105,7 @@ class ClassMetadataTest extends \PHPUnit\Framework\TestCase
 		);
 
 		$classMetadata = new ClassMetadata('FooClass', [$fooProperty]);
-		$this->assertSame($fooProperty, $classMetadata->getPropertyByName($propertyName));
+		Assert::assertSame($fooProperty, $classMetadata->getPropertyByName($propertyName));
 	}
 
 	public function testGetPropertyByNameNotFound(): void
@@ -114,10 +116,10 @@ class ClassMetadataTest extends \PHPUnit\Framework\TestCase
 
 		try {
 			$classMetadata->getPropertyByName($propertyName);
-			$this->fail();
+			Assert::fail();
 		} catch (\Consistence\Sentry\Metadata\PropertyNotFoundException $e) {
-			$this->assertSame($className, $e->getClassName());
-			$this->assertSame($propertyName, $e->getPropertyName());
+			Assert::assertSame($className, $e->getClassName());
+			Assert::assertSame($propertyName, $e->getPropertyName());
 		}
 	}
 

--- a/tests/Metadata/PropertyMetadataTest.php
+++ b/tests/Metadata/PropertyMetadataTest.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace Consistence\Sentry\Metadata;
 
+use PHPUnit\Framework\Assert;
+
 class PropertyMetadataTest extends \PHPUnit\Framework\TestCase
 {
 
@@ -40,13 +42,13 @@ class PropertyMetadataTest extends \PHPUnit\Framework\TestCase
 			$bidirectionalAssociation
 		);
 
-		$this->assertSame('fooProperty', $property->getName());
-		$this->assertSame('FooClass', $property->getClassName());
-		$this->assertSame($targetClass, $property->getType());
-		$this->assertSame($sentryIdentificator, $property->getSentryIdentificator());
-		$this->assertSame(false, $property->isNullable());
-		$this->assertSame($sentryMethods, $property->getSentryMethods());
-		$this->assertSame($bidirectionalAssociation, $property->getBidirectionalAssociation());
+		Assert::assertSame('fooProperty', $property->getName());
+		Assert::assertSame('FooClass', $property->getClassName());
+		Assert::assertSame($targetClass, $property->getType());
+		Assert::assertSame($sentryIdentificator, $property->getSentryIdentificator());
+		Assert::assertSame(false, $property->isNullable());
+		Assert::assertSame($sentryMethods, $property->getSentryMethods());
+		Assert::assertSame($bidirectionalAssociation, $property->getBidirectionalAssociation());
 	}
 
 	public function testCreateScalar(): void
@@ -62,13 +64,13 @@ class PropertyMetadataTest extends \PHPUnit\Framework\TestCase
 			null
 		);
 
-		$this->assertSame('fooProperty', $property->getName());
-		$this->assertSame('FooClass', $property->getClassName());
-		$this->assertSame('int', $property->getType());
-		$this->assertSame($sentryIdentificator, $property->getSentryIdentificator());
-		$this->assertSame(false, $property->isNullable());
-		$this->assertEmpty($property->getSentryMethods());
-		$this->assertNull($property->getBidirectionalAssociation());
+		Assert::assertSame('fooProperty', $property->getName());
+		Assert::assertSame('FooClass', $property->getClassName());
+		Assert::assertSame('int', $property->getType());
+		Assert::assertSame($sentryIdentificator, $property->getSentryIdentificator());
+		Assert::assertSame(false, $property->isNullable());
+		Assert::assertEmpty($property->getSentryMethods());
+		Assert::assertNull($property->getBidirectionalAssociation());
 	}
 
 	public function testGetSentryMethodByAccess(): void
@@ -98,7 +100,7 @@ class PropertyMetadataTest extends \PHPUnit\Framework\TestCase
 			null
 		);
 
-		$this->assertSame($setMethod, $property->getSentryMethodByAccessAndRequiredVisibility(
+		Assert::assertSame($setMethod, $property->getSentryMethodByAccessAndRequiredVisibility(
 			new SentryAccess('set'),
 			Visibility::get(Visibility::VISIBILITY_PRIVATE)
 		));
@@ -151,7 +153,7 @@ class PropertyMetadataTest extends \PHPUnit\Framework\TestCase
 			null
 		);
 
-		$this->assertSame($fooMethod, $property->getSentryMethodByNameAndRequiredVisibility(
+		Assert::assertSame($fooMethod, $property->getSentryMethodByNameAndRequiredVisibility(
 			'fooMethod',
 			Visibility::get(Visibility::VISIBILITY_PRIVATE)
 		));
@@ -174,11 +176,11 @@ class PropertyMetadataTest extends \PHPUnit\Framework\TestCase
 				'fooMethod',
 				Visibility::get(Visibility::VISIBILITY_PUBLIC)
 			);
-			$this->fail();
+			Assert::fail();
 		} catch (\Consistence\Sentry\Metadata\MethodNotFoundForPropertyException $e) {
-			$this->assertSame('FooClass', $e->getClassName());
-			$this->assertSame('fooProperty', $e->getPropertyName());
-			$this->assertSame('fooMethod', $e->getMethodName());
+			Assert::assertSame('FooClass', $e->getClassName());
+			Assert::assertSame('fooProperty', $e->getPropertyName());
+			Assert::assertSame('fooMethod', $e->getMethodName());
 		}
 	}
 
@@ -200,7 +202,7 @@ class PropertyMetadataTest extends \PHPUnit\Framework\TestCase
 			null
 		);
 
-		$this->assertSame($fooMethod, $property->getSentryMethodByNameAndRequiredVisibility(
+		Assert::assertSame($fooMethod, $property->getSentryMethodByNameAndRequiredVisibility(
 			'FOOmethod',
 			Visibility::get(Visibility::VISIBILITY_PRIVATE)
 		));
@@ -233,7 +235,7 @@ class PropertyMetadataTest extends \PHPUnit\Framework\TestCase
 			null
 		);
 
-		$this->assertEquals([new SentryAccess('set')], $property->getDefinedSentryAccess());
+		Assert::assertEquals([new SentryAccess('set')], $property->getDefinedSentryAccess());
 	}
 
 }

--- a/tests/Metadata/PropertyMetadataTest.php
+++ b/tests/Metadata/PropertyMetadataTest.php
@@ -115,9 +115,11 @@ class PropertyMetadataTest extends \PHPUnit\Framework\TestCase
 			'setFoo',
 			Visibility::get(Visibility::VISIBILITY_PRIVATE)
 		);
+		$className = 'FooClass';
+		$propertyName = 'fooProperty';
 		$property = new PropertyMetadata(
-			'fooProperty',
-			'FooClass',
+			$propertyName,
+			$className,
 			$targetClass,
 			$sentryIdentificator,
 			false,
@@ -127,12 +129,19 @@ class PropertyMetadataTest extends \PHPUnit\Framework\TestCase
 			null
 		);
 
-		$this->expectException(\Consistence\Sentry\Metadata\NoSuitableMethodException::class);
+		$sentryAccess = new SentryAccess('set');
 
-		$property->getSentryMethodByAccessAndRequiredVisibility(
-			new SentryAccess('set'),
-			Visibility::get(Visibility::VISIBILITY_PUBLIC)
-		);
+		try {
+			$property->getSentryMethodByAccessAndRequiredVisibility(
+				$sentryAccess,
+				Visibility::get(Visibility::VISIBILITY_PUBLIC)
+			);
+			Assert::fail('Exception expected');
+		} catch (\Consistence\Sentry\Metadata\NoSuitableMethodException $e) {
+			Assert::assertSame($className, $e->getClassName());
+			Assert::assertSame($propertyName, $e->getPropertyName());
+			Assert::assertSame($sentryAccess, $e->getSentryAccess());
+		}
 	}
 
 	public function testGetSentryMethodByNameAndRequiredVisibility(): void

--- a/tests/Metadata/PropertyMetadataTest.php
+++ b/tests/Metadata/PropertyMetadataTest.php
@@ -176,7 +176,7 @@ class PropertyMetadataTest extends \PHPUnit\Framework\TestCase
 				'fooMethod',
 				Visibility::get(Visibility::VISIBILITY_PUBLIC)
 			);
-			Assert::fail();
+			Assert::fail('Exception expected');
 		} catch (\Consistence\Sentry\Metadata\MethodNotFoundForPropertyException $e) {
 			Assert::assertSame('FooClass', $e->getClassName());
 			Assert::assertSame('fooProperty', $e->getPropertyName());

--- a/tests/Metadata/PropertyMetadataTest.php
+++ b/tests/Metadata/PropertyMetadataTest.php
@@ -4,73 +4,102 @@ declare(strict_types = 1);
 
 namespace Consistence\Sentry\Metadata;
 
+use Generator;
 use PHPUnit\Framework\Assert;
 
 class PropertyMetadataTest extends \PHPUnit\Framework\TestCase
 {
 
-	public function testCreate(): void
+	/**
+	 * @return mixed[][]|\Generator
+	 */
+	public function createDataProvider(): Generator
 	{
-		$targetClass = 'BarClass';
-		$sentryIdentificator = new SentryIdentificator($targetClass);
-		$sentryMethods = [
-			new SentryMethod(
-				new SentryAccess('get'),
-				'fooMethod',
-				Visibility::get(Visibility::VISIBILITY_PUBLIC)
-			),
-		];
-		$bidirectionalAssociation = new BidirectionalAssociation(
-			$targetClass,
-			'barProperty',
-			BidirectionalAssociationType::get(BidirectionalAssociationType::ONE),
-			[
-				new SentryMethod(
-					new SentryAccess('get'),
-					'barMethod',
-					Visibility::get(Visibility::VISIBILITY_PUBLIC)
+		yield 'create object' => (function (): array {
+			$targetType = 'BarClass';
+
+			return [
+				'name' => 'fooProperty',
+				'className' => 'FooClass',
+				'targetType' => $targetType,
+				'sentryIdentificator' => new SentryIdentificator($targetType),
+				'nullable' => false,
+				'sentryMethods' => [
+					new SentryMethod(
+						new SentryAccess('get'),
+						'fooMethod',
+						Visibility::get(Visibility::VISIBILITY_PUBLIC)
+					),
+				],
+				'bidirectionalAssociation' => new BidirectionalAssociation(
+					$targetType,
+					'barProperty',
+					BidirectionalAssociationType::get(BidirectionalAssociationType::ONE),
+					[
+						new SentryMethod(
+							new SentryAccess('get'),
+							'barMethod',
+							Visibility::get(Visibility::VISIBILITY_PUBLIC)
+						),
+					]
 				),
-			]
-		);
+			];
+		})();
+
+		yield 'create scalar' => (function (): array {
+			$targetType = 'int';
+
+			return [
+				'name' => 'fooProperty',
+				'className' => 'FooClass',
+				'targetType' => $targetType,
+				'sentryIdentificator' => new SentryIdentificator($targetType),
+				'nullable' => false,
+				'sentryMethods' => [],
+				'bidirectionalAssociation' => null,
+			];
+		})();
+	}
+
+	/**
+	 * @dataProvider createDataProvider
+	 *
+	 * @param string $name
+	 * @param string $className
+	 * @param string $targetType
+	 * @param \Consistence\Sentry\Metadata\SentryIdentificator $sentryIdentificator
+	 * @param bool $nullable
+	 * @param \Consistence\Sentry\Metadata\SentryMethod[] $sentryMethods
+	 * @param \Consistence\Sentry\Metadata\BidirectionalAssociation|null $bidirectionalAssociation
+	 * @return void
+	 */
+	public function testCreate(
+		string $name,
+		string $className,
+		string $targetType,
+		SentryIdentificator $sentryIdentificator,
+		bool $nullable,
+		array $sentryMethods,
+		?BidirectionalAssociation $bidirectionalAssociation
+	): void
+	{
 		$property = new PropertyMetadata(
-			'fooProperty',
-			'FooClass',
-			$targetClass,
+			$name,
+			$className,
+			$targetType,
 			$sentryIdentificator,
-			false,
+			$nullable,
 			$sentryMethods,
 			$bidirectionalAssociation
 		);
 
-		Assert::assertSame('fooProperty', $property->getName());
-		Assert::assertSame('FooClass', $property->getClassName());
-		Assert::assertSame($targetClass, $property->getType());
+		Assert::assertSame($name, $property->getName());
+		Assert::assertSame($className, $property->getClassName());
+		Assert::assertSame($targetType, $property->getType());
 		Assert::assertSame($sentryIdentificator, $property->getSentryIdentificator());
-		Assert::assertSame(false, $property->isNullable());
+		Assert::assertSame($nullable, $property->isNullable());
 		Assert::assertSame($sentryMethods, $property->getSentryMethods());
 		Assert::assertSame($bidirectionalAssociation, $property->getBidirectionalAssociation());
-	}
-
-	public function testCreateScalar(): void
-	{
-		$sentryIdentificator = new SentryIdentificator('int');
-		$property = new PropertyMetadata(
-			'fooProperty',
-			'FooClass',
-			'int',
-			$sentryIdentificator,
-			false,
-			[],
-			null
-		);
-
-		Assert::assertSame('fooProperty', $property->getName());
-		Assert::assertSame('FooClass', $property->getClassName());
-		Assert::assertSame('int', $property->getType());
-		Assert::assertSame($sentryIdentificator, $property->getSentryIdentificator());
-		Assert::assertSame(false, $property->isNullable());
-		Assert::assertEmpty($property->getSentryMethods());
-		Assert::assertNull($property->getBidirectionalAssociation());
 	}
 
 	public function testGetSentryMethodByAccess(): void
@@ -144,27 +173,76 @@ class PropertyMetadataTest extends \PHPUnit\Framework\TestCase
 		}
 	}
 
-	public function testGetSentryMethodByNameAndRequiredVisibility(): void
+	/**
+	 * @return mixed[][]|\Generator
+	 */
+	public function getSentryMethodByNameAndRequiredVisibilityDataProvider(): Generator
 	{
-		$sentryIdentificator = new SentryIdentificator('string');
-		$fooMethod = new SentryMethod(
-			new SentryAccess('get'),
-			'fooMethod',
-			Visibility::get(Visibility::VISIBILITY_PUBLIC)
-		);
-		$property = new PropertyMetadata(
-			'fooProperty',
-			'FooClass',
-			'string',
-			$sentryIdentificator,
-			false,
-			[$fooMethod],
-			null
-		);
+		yield 'case sensitive' => (function (): array {
+			$fooMethod = new SentryMethod(
+				new SentryAccess('get'),
+				'fooMethod',
+				Visibility::get(Visibility::VISIBILITY_PUBLIC)
+			);
 
-		Assert::assertSame($fooMethod, $property->getSentryMethodByNameAndRequiredVisibility(
-			'fooMethod',
-			Visibility::get(Visibility::VISIBILITY_PRIVATE)
+			return [
+				'expectedSentryMethod' => $fooMethod,
+				'propertyMetadata' => new PropertyMetadata(
+					'fooProperty',
+					'FooClass',
+					'string',
+					new SentryIdentificator('string'),
+					false,
+					[$fooMethod],
+					null
+				),
+				'methodName' => 'fooMethod',
+				'requiredVisibility' => Visibility::get(Visibility::VISIBILITY_PRIVATE),
+			];
+		})();
+
+		yield 'case insensitive' => (function (): array {
+			$fooMethod = new SentryMethod(
+				new SentryAccess('get'),
+				'fooMethod',
+				Visibility::get(Visibility::VISIBILITY_PUBLIC)
+			);
+
+			return [
+				'expectedSentryMethod' => $fooMethod,
+				'propertyMetadata' => new PropertyMetadata(
+					'fooProperty',
+					'FooClass',
+					'string',
+					new SentryIdentificator('string'),
+					false,
+					[$fooMethod],
+					null
+				),
+				'methodName' => 'FOOMethod',
+				'requiredVisibility' => Visibility::get(Visibility::VISIBILITY_PRIVATE),
+			];
+		})();
+	}
+
+	/**
+	 * @dataProvider getSentryMethodByNameAndRequiredVisibilityDataProvider
+	 *
+	 * @param \Consistence\Sentry\Metadata\SentryMethod $expectedSentryMethod
+	 * @param \Consistence\Sentry\Metadata\PropertyMetadata $propertyMetadata
+	 * @param string $methodName
+	 * @param \Consistence\Sentry\Metadata\Visibility $requiredVisibility
+	 */
+	public function testGetSentryMethodByNameAndRequiredVisibility(
+		SentryMethod $expectedSentryMethod,
+		PropertyMetadata $propertyMetadata,
+		string $methodName,
+		Visibility $requiredVisibility
+	): void
+	{
+		Assert::assertSame($expectedSentryMethod, $propertyMetadata->getSentryMethodByNameAndRequiredVisibility(
+			$methodName,
+			$requiredVisibility
 		));
 	}
 
@@ -191,30 +269,6 @@ class PropertyMetadataTest extends \PHPUnit\Framework\TestCase
 			Assert::assertSame('fooProperty', $e->getPropertyName());
 			Assert::assertSame('fooMethod', $e->getMethodName());
 		}
-	}
-
-	public function testGetSentryMethodByNameAndRequiredVisibilityCaseInsensitive(): void
-	{
-		$sentryIdentificator = new SentryIdentificator('string');
-		$fooMethod = new SentryMethod(
-			new SentryAccess('get'),
-			'fooMethod',
-			Visibility::get(Visibility::VISIBILITY_PUBLIC)
-		);
-		$property = new PropertyMetadata(
-			'fooProperty',
-			'FooClass',
-			'string',
-			$sentryIdentificator,
-			false,
-			[$fooMethod],
-			null
-		);
-
-		Assert::assertSame($fooMethod, $property->getSentryMethodByNameAndRequiredVisibility(
-			'FOOmethod',
-			Visibility::get(Visibility::VISIBILITY_PRIVATE)
-		));
 	}
 
 	public function testGetDefinedSentryAccess(): void

--- a/tests/Metadata/SentryAccessTest.php
+++ b/tests/Metadata/SentryAccessTest.php
@@ -4,25 +4,27 @@ declare(strict_types = 1);
 
 namespace Consistence\Sentry\Metadata;
 
+use PHPUnit\Framework\Assert;
+
 class SentryAccessTest extends \PHPUnit\Framework\TestCase
 {
 
 	public function testCreate(): void
 	{
 		$sentryAccess = new SentryAccess('foo');
-		$this->assertSame('foo', $sentryAccess->getName());
+		Assert::assertSame('foo', $sentryAccess->getName());
 	}
 
 	public function testEquals(): void
 	{
 		$sentryAccess = new SentryAccess('foo');
-		$this->assertTrue($sentryAccess->equals(new SentryAccess('foo')));
+		Assert::assertTrue($sentryAccess->equals(new SentryAccess('foo')));
 	}
 
 	public function testNotEquals(): void
 	{
 		$sentryAccess = new SentryAccess('foo');
-		$this->assertFalse($sentryAccess->equals(new SentryAccess('bar')));
+		Assert::assertFalse($sentryAccess->equals(new SentryAccess('bar')));
 	}
 
 }

--- a/tests/Metadata/SentryAccessTest.php
+++ b/tests/Metadata/SentryAccessTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Consistence\Sentry\Metadata;
 
+use Generator;
 use PHPUnit\Framework\Assert;
 
 class SentryAccessTest extends \PHPUnit\Framework\TestCase
@@ -15,16 +16,37 @@ class SentryAccessTest extends \PHPUnit\Framework\TestCase
 		Assert::assertSame('foo', $sentryAccess->getName());
 	}
 
-	public function testEquals(): void
+	/**
+	 * @return mixed[][]|\Generator
+	 */
+	public function equalsDataProvider(): Generator
 	{
-		$sentryAccess = new SentryAccess('foo');
-		Assert::assertTrue($sentryAccess->equals(new SentryAccess('foo')));
+		yield 'same name' => [
+			'firstSentryAccess' => new SentryAccess('foo'),
+			'secondSentryAccess' => new SentryAccess('foo'),
+			'expectedEquals' => true,
+		];
+		yield 'different name' => [
+			'firstSentryAccess' => new SentryAccess('foo'),
+			'secondSentryAccess' => new SentryAccess('bar'),
+			'expectedEquals' => false,
+		];
 	}
 
-	public function testNotEquals(): void
+	/**
+	 * @dataProvider equalsDataProvider
+	 *
+	 * @param \Consistence\Sentry\Metadata\SentryAccess $firstSentryAccess
+	 * @param \Consistence\Sentry\Metadata\SentryAccess $secondSentryAccess
+	 * @param bool $expectedEquals
+	 */
+	public function testEquals(
+		SentryAccess $firstSentryAccess,
+		SentryAccess $secondSentryAccess,
+		bool $expectedEquals
+	): void
 	{
-		$sentryAccess = new SentryAccess('foo');
-		Assert::assertFalse($sentryAccess->equals(new SentryAccess('bar')));
+		Assert::assertSame($expectedEquals, $firstSentryAccess->equals($secondSentryAccess));
 	}
 
 }

--- a/tests/Metadata/SentryIdentificatorTest.php
+++ b/tests/Metadata/SentryIdentificatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Consistence\Sentry\Metadata;
 
+use PHPUnit\Framework\Assert;
 use stdClass;
 
 class SentryIdentificatorTest extends \PHPUnit\Framework\TestCase
@@ -12,26 +13,26 @@ class SentryIdentificatorTest extends \PHPUnit\Framework\TestCase
 	public function testCreate(): void
 	{
 		$sentryIdentificator = new SentryIdentificator('foo');
-		$this->assertSame('foo', $sentryIdentificator->getId());
+		Assert::assertSame('foo', $sentryIdentificator->getId());
 	}
 
 	public function testCreateObjectId(): void
 	{
 		$object = new stdClass();
 		$sentryIdentificator = new SentryIdentificator($object);
-		$this->assertSame($object, $sentryIdentificator->getId());
+		Assert::assertSame($object, $sentryIdentificator->getId());
 	}
 
 	public function testEquals(): void
 	{
 		$sentryIdentificator = new SentryIdentificator('foo');
-		$this->assertTrue($sentryIdentificator->equals(new SentryIdentificator('foo')));
+		Assert::assertTrue($sentryIdentificator->equals(new SentryIdentificator('foo')));
 	}
 
 	public function testNotEquals(): void
 	{
 		$sentryIdentificator = new SentryIdentificator('foo');
-		$this->assertFalse($sentryIdentificator->equals(new SentryIdentificator('bar')));
+		Assert::assertFalse($sentryIdentificator->equals(new SentryIdentificator('bar')));
 	}
 
 }

--- a/tests/Metadata/SentryIdentificatorTest.php
+++ b/tests/Metadata/SentryIdentificatorTest.php
@@ -4,35 +4,68 @@ declare(strict_types = 1);
 
 namespace Consistence\Sentry\Metadata;
 
+use Generator;
 use PHPUnit\Framework\Assert;
 use stdClass;
 
 class SentryIdentificatorTest extends \PHPUnit\Framework\TestCase
 {
 
-	public function testCreate(): void
+	/**
+	 * @return mixed[][]|\Generator
+	 */
+	public function createDataProvider(): Generator
 	{
-		$sentryIdentificator = new SentryIdentificator('foo');
-		Assert::assertSame('foo', $sentryIdentificator->getId());
+		yield 'id is string' => [
+			'id' => 'foo',
+		];
+		yield 'is is object' => [
+			'id' => new stdClass(),
+		];
 	}
 
-	public function testCreateObjectId(): void
+	/**
+	 * @dataProvider createDataProvider
+	 *
+	 * @param mixed $id
+	 */
+	public function testCreate($id): void
 	{
-		$object = new stdClass();
-		$sentryIdentificator = new SentryIdentificator($object);
-		Assert::assertSame($object, $sentryIdentificator->getId());
+		$sentryIdentificator = new SentryIdentificator($id);
+		Assert::assertSame($id, $sentryIdentificator->getId());
 	}
 
-	public function testEquals(): void
+	/**
+	 * @return mixed[][]|\Generator
+	 */
+	public function equalsDataProvider(): Generator
 	{
-		$sentryIdentificator = new SentryIdentificator('foo');
-		Assert::assertTrue($sentryIdentificator->equals(new SentryIdentificator('foo')));
+		yield 'same name' => [
+			'firstSentryIdentificator' => new SentryIdentificator('foo'),
+			'secondSentryIdentificator' => new SentryIdentificator('foo'),
+			'expectedEquals' => true,
+		];
+		yield 'different name' => [
+			'firstSentryIdentificator' => new SentryIdentificator('foo'),
+			'secondSentryIdentificator' => new SentryIdentificator('bar'),
+			'expectedEquals' => false,
+		];
 	}
 
-	public function testNotEquals(): void
+	/**
+	 * @dataProvider equalsDataProvider
+	 *
+	 * @param \Consistence\Sentry\Metadata\SentryIdentificator $firstSentryIdentificator
+	 * @param \Consistence\Sentry\Metadata\SentryIdentificator $secondSentryIdentificator
+	 * @param bool $expectedEquals
+	 */
+	public function testEquals(
+		SentryIdentificator $firstSentryIdentificator,
+		SentryIdentificator $secondSentryIdentificator,
+		bool $expectedEquals
+	): void
 	{
-		$sentryIdentificator = new SentryIdentificator('foo');
-		Assert::assertFalse($sentryIdentificator->equals(new SentryIdentificator('bar')));
+		Assert::assertSame($expectedEquals, $firstSentryIdentificator->equals($secondSentryIdentificator));
 	}
 
 }

--- a/tests/Metadata/SentryMethodTest.php
+++ b/tests/Metadata/SentryMethodTest.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace Consistence\Sentry\Metadata;
 
+use PHPUnit\Framework\Assert;
+
 class SentryMethodTest extends \PHPUnit\Framework\TestCase
 {
 
@@ -15,9 +17,9 @@ class SentryMethodTest extends \PHPUnit\Framework\TestCase
 			Visibility::get(Visibility::VISIBILITY_PUBLIC)
 		);
 
-		$this->assertTrue($sentryMethod->getSentryAccess()->equals(new SentryAccess('get')));
-		$this->assertSame('foo', $sentryMethod->getMethodName());
-		$this->assertSame(Visibility::get(Visibility::VISIBILITY_PUBLIC), $sentryMethod->getMethodVisibility());
+		Assert::assertTrue($sentryMethod->getSentryAccess()->equals(new SentryAccess('get')));
+		Assert::assertSame('foo', $sentryMethod->getMethodName());
+		Assert::assertSame(Visibility::get(Visibility::VISIBILITY_PUBLIC), $sentryMethod->getMethodVisibility());
 	}
 
 }

--- a/tests/Metadata/VisibilityTest.php
+++ b/tests/Metadata/VisibilityTest.php
@@ -47,7 +47,7 @@ class VisibilityTest extends \PHPUnit\Framework\TestCase
 
 	public function testGetRequiredVisibilitySameClass(): void
 	{
-		Assert::assertEquals(
+		Assert::assertSame(
 			Visibility::get(Visibility::VISIBILITY_PRIVATE),
 			Visibility::getRequiredVisibility(FooClass::class, FooClass::class)
 		);
@@ -55,7 +55,7 @@ class VisibilityTest extends \PHPUnit\Framework\TestCase
 
 	public function testGetRequiredVisibilityClassExtends(): void
 	{
-		Assert::assertEquals(
+		Assert::assertSame(
 			Visibility::get(Visibility::VISIBILITY_PROTECTED),
 			Visibility::getRequiredVisibility(FooClass::class, BarClass::class)
 		);
@@ -63,7 +63,7 @@ class VisibilityTest extends \PHPUnit\Framework\TestCase
 
 	public function testGetRequiredVisibilityClassExtended(): void
 	{
-		Assert::assertEquals(
+		Assert::assertSame(
 			Visibility::get(Visibility::VISIBILITY_PROTECTED),
 			Visibility::getRequiredVisibility(BarClass::class, FooClass::class)
 		);
@@ -71,7 +71,7 @@ class VisibilityTest extends \PHPUnit\Framework\TestCase
 
 	public function testGetRequiredVisibilityNoRelationClasses(): void
 	{
-		Assert::assertEquals(
+		Assert::assertSame(
 			Visibility::get(Visibility::VISIBILITY_PUBLIC),
 			Visibility::getRequiredVisibility(FooClass::class, BazClass::class)
 		);

--- a/tests/Metadata/VisibilityTest.php
+++ b/tests/Metadata/VisibilityTest.php
@@ -4,16 +4,38 @@ declare(strict_types = 1);
 
 namespace Consistence\Sentry\Metadata;
 
+use Generator;
 use PHPUnit\Framework\Assert;
 
 class VisibilityTest extends \PHPUnit\Framework\TestCase
 {
 
-	public function testCreate(): void
+	/**
+	 * @return mixed[][]|\Generator
+	 */
+	public function validVisibilityValueDataProvider(): Generator
 	{
-		Assert::assertInstanceOf(Visibility::class, Visibility::get(Visibility::VISIBILITY_PRIVATE));
-		Assert::assertInstanceOf(Visibility::class, Visibility::get(Visibility::VISIBILITY_PROTECTED));
-		Assert::assertInstanceOf(Visibility::class, Visibility::get(Visibility::VISIBILITY_PUBLIC));
+		yield 'private' => [
+			'value' => Visibility::VISIBILITY_PRIVATE,
+		];
+
+		yield 'protected' => [
+			'value' => Visibility::VISIBILITY_PROTECTED,
+		];
+
+		yield 'public' => [
+			'value' => Visibility::VISIBILITY_PUBLIC,
+		];
+	}
+
+	/**
+	 * @dataProvider validVisibilityValueDataProvider
+	 *
+	 * @param mixed $value
+	 */
+	public function testCreate($value): void
+	{
+		Assert::assertInstanceOf(Visibility::class, Visibility::get($value));
 	}
 
 	public function testGetName(): void

--- a/tests/Metadata/VisibilityTest.php
+++ b/tests/Metadata/VisibilityTest.php
@@ -4,48 +4,50 @@ declare(strict_types = 1);
 
 namespace Consistence\Sentry\Metadata;
 
+use PHPUnit\Framework\Assert;
+
 class VisibilityTest extends \PHPUnit\Framework\TestCase
 {
 
 	public function testCreate(): void
 	{
-		$this->assertInstanceOf(Visibility::class, Visibility::get(Visibility::VISIBILITY_PRIVATE));
-		$this->assertInstanceOf(Visibility::class, Visibility::get(Visibility::VISIBILITY_PROTECTED));
-		$this->assertInstanceOf(Visibility::class, Visibility::get(Visibility::VISIBILITY_PUBLIC));
+		Assert::assertInstanceOf(Visibility::class, Visibility::get(Visibility::VISIBILITY_PRIVATE));
+		Assert::assertInstanceOf(Visibility::class, Visibility::get(Visibility::VISIBILITY_PROTECTED));
+		Assert::assertInstanceOf(Visibility::class, Visibility::get(Visibility::VISIBILITY_PUBLIC));
 	}
 
 	public function testGetName(): void
 	{
-		$this->assertSame('public', Visibility::get(Visibility::VISIBILITY_PUBLIC)->getName());
+		Assert::assertSame('public', Visibility::get(Visibility::VISIBILITY_PUBLIC)->getName());
 	}
 
 	public function testLooserOrEqualVisibilityPublic(): void
 	{
 		$public = Visibility::get(Visibility::VISIBILITY_PUBLIC);
-		$this->assertTrue($public->isLooserOrEqualTo(Visibility::get(Visibility::VISIBILITY_PUBLIC)));
-		$this->assertTrue($public->isLooserOrEqualTo(Visibility::get(Visibility::VISIBILITY_PROTECTED)));
-		$this->assertTrue($public->isLooserOrEqualTo(Visibility::get(Visibility::VISIBILITY_PRIVATE)));
+		Assert::assertTrue($public->isLooserOrEqualTo(Visibility::get(Visibility::VISIBILITY_PUBLIC)));
+		Assert::assertTrue($public->isLooserOrEqualTo(Visibility::get(Visibility::VISIBILITY_PROTECTED)));
+		Assert::assertTrue($public->isLooserOrEqualTo(Visibility::get(Visibility::VISIBILITY_PRIVATE)));
 	}
 
 	public function testLooserOrEqualVisibilityProtected(): void
 	{
 		$protected = Visibility::get(Visibility::VISIBILITY_PROTECTED);
-		$this->assertFalse($protected->isLooserOrEqualTo(Visibility::get(Visibility::VISIBILITY_PUBLIC)));
-		$this->assertTrue($protected->isLooserOrEqualTo(Visibility::get(Visibility::VISIBILITY_PROTECTED)));
-		$this->assertTrue($protected->isLooserOrEqualTo(Visibility::get(Visibility::VISIBILITY_PRIVATE)));
+		Assert::assertFalse($protected->isLooserOrEqualTo(Visibility::get(Visibility::VISIBILITY_PUBLIC)));
+		Assert::assertTrue($protected->isLooserOrEqualTo(Visibility::get(Visibility::VISIBILITY_PROTECTED)));
+		Assert::assertTrue($protected->isLooserOrEqualTo(Visibility::get(Visibility::VISIBILITY_PRIVATE)));
 	}
 
 	public function testLooserOrEqualVisibilityPrivate(): void
 	{
 		$private = Visibility::get(Visibility::VISIBILITY_PRIVATE);
-		$this->assertFalse($private->isLooserOrEqualTo(Visibility::get(Visibility::VISIBILITY_PUBLIC)));
-		$this->assertFalse($private->isLooserOrEqualTo(Visibility::get(Visibility::VISIBILITY_PROTECTED)));
-		$this->assertTrue($private->isLooserOrEqualTo(Visibility::get(Visibility::VISIBILITY_PRIVATE)));
+		Assert::assertFalse($private->isLooserOrEqualTo(Visibility::get(Visibility::VISIBILITY_PUBLIC)));
+		Assert::assertFalse($private->isLooserOrEqualTo(Visibility::get(Visibility::VISIBILITY_PROTECTED)));
+		Assert::assertTrue($private->isLooserOrEqualTo(Visibility::get(Visibility::VISIBILITY_PRIVATE)));
 	}
 
 	public function testGetRequiredVisibilitySameClass(): void
 	{
-		$this->assertEquals(
+		Assert::assertEquals(
 			Visibility::get(Visibility::VISIBILITY_PRIVATE),
 			Visibility::getRequiredVisibility(FooClass::class, FooClass::class)
 		);
@@ -53,7 +55,7 @@ class VisibilityTest extends \PHPUnit\Framework\TestCase
 
 	public function testGetRequiredVisibilityClassExtends(): void
 	{
-		$this->assertEquals(
+		Assert::assertEquals(
 			Visibility::get(Visibility::VISIBILITY_PROTECTED),
 			Visibility::getRequiredVisibility(FooClass::class, BarClass::class)
 		);
@@ -61,7 +63,7 @@ class VisibilityTest extends \PHPUnit\Framework\TestCase
 
 	public function testGetRequiredVisibilityClassExtended(): void
 	{
-		$this->assertEquals(
+		Assert::assertEquals(
 			Visibility::get(Visibility::VISIBILITY_PROTECTED),
 			Visibility::getRequiredVisibility(BarClass::class, FooClass::class)
 		);
@@ -69,7 +71,7 @@ class VisibilityTest extends \PHPUnit\Framework\TestCase
 
 	public function testGetRequiredVisibilityNoRelationClasses(): void
 	{
-		$this->assertEquals(
+		Assert::assertEquals(
 			Visibility::get(Visibility::VISIBILITY_PUBLIC),
 			Visibility::getRequiredVisibility(FooClass::class, BazClass::class)
 		);

--- a/tests/MetadataSource/Annotation/AnnotationMetadataSourceTest.php
+++ b/tests/MetadataSource/Annotation/AnnotationMetadataSourceTest.php
@@ -14,6 +14,7 @@ use Consistence\Sentry\Metadata\Visibility;
 use Consistence\Sentry\MetadataSource\FooClass;
 use Consistence\Sentry\SentryIdentificatorParser\SentryIdentificatorParser;
 use Consistence\Sentry\Type\SimpleType;
+use PHPUnit\Framework\Assert;
 use ReflectionClass;
 use ReflectionProperty;
 
@@ -44,21 +45,21 @@ class AnnotationMetadataSourceTest extends \PHPUnit\Framework\TestCase
 
 		$sentryFactory = $this->createMock(SentryFactory::class);
 		$sentryFactory
-			->expects($this->once())
+			->expects(self::once())
 			->method('getSentry')
 			->with($sentryIdentificator)
-			->will($this->returnValue(new SimpleType()));
+			->will(self::returnValue(new SimpleType()));
 
 		$annotationProvider = $this->createMock(AnnotationProvider::class);
 		$annotationProvider
-			->expects($this->once())
+			->expects(self::once())
 			->method('getPropertyAnnotation')
-			->with($classReflection->getProperty($propertyName), $this->isType('string'))
-			->will($this->returnValue($sentryIdentificatorAnnotation));
+			->with($classReflection->getProperty($propertyName), Assert::isType('string'))
+			->will(self::returnValue($sentryIdentificatorAnnotation));
 		$annotationProvider
-			->expects($this->exactly(2))
+			->expects(self::exactly(2))
 			->method('getPropertyAnnotations')
-			->will($this->returnCallback($getAnnotationsCallback));
+			->will(self::returnCallback($getAnnotationsCallback));
 
 		$metadataSource = new AnnotationMetadataSource(
 			$sentryFactory,
@@ -67,22 +68,22 @@ class AnnotationMetadataSourceTest extends \PHPUnit\Framework\TestCase
 		);
 		$classMetadata = $metadataSource->getMetadataForClass($classReflection);
 
-		$this->assertSame($className, $classMetadata->getName());
+		Assert::assertSame($className, $classMetadata->getName());
 		$properties = $classMetadata->getProperties();
-		$this->assertCount(1, $properties);
+		Assert::assertCount(1, $properties);
 		$fooProperty = $properties[0];
-		$this->assertSame($propertyName, $fooProperty->getName());
-		$this->assertSame($className, $fooProperty->getClassName());
-		$this->assertSame($type, $fooProperty->getType());
-		$this->assertTrue($sentryIdentificator->equals($fooProperty->getSentryIdentificator()));
-		$this->assertFalse($fooProperty->isNullable());
+		Assert::assertSame($propertyName, $fooProperty->getName());
+		Assert::assertSame($className, $fooProperty->getClassName());
+		Assert::assertSame($type, $fooProperty->getType());
+		Assert::assertTrue($sentryIdentificator->equals($fooProperty->getSentryIdentificator()));
+		Assert::assertFalse($fooProperty->isNullable());
 		$sentryMethods = $fooProperty->getSentryMethods();
-		$this->assertCount(1, $sentryMethods);
+		Assert::assertCount(1, $sentryMethods);
 		$getMethod = $sentryMethods[0];
-		$this->assertSame('getFooProperty', $getMethod->getMethodName());
-		$this->assertSame(Visibility::get(Visibility::VISIBILITY_PUBLIC), $getMethod->getMethodVisibility());
-		$this->assertTrue($getMethod->getSentryAccess()->equals(new SentryAccess('get')));
-		$this->assertNull($fooProperty->getBidirectionalAssociation());
+		Assert::assertSame('getFooProperty', $getMethod->getMethodName());
+		Assert::assertSame(Visibility::get(Visibility::VISIBILITY_PUBLIC), $getMethod->getMethodVisibility());
+		Assert::assertTrue($getMethod->getSentryAccess()->equals(new SentryAccess('get')));
+		Assert::assertNull($fooProperty->getBidirectionalAssociation());
 	}
 
 	public function testCustomMethodName(): void
@@ -111,21 +112,21 @@ class AnnotationMetadataSourceTest extends \PHPUnit\Framework\TestCase
 
 		$sentryFactory = $this->createMock(SentryFactory::class);
 		$sentryFactory
-			->expects($this->once())
+			->expects(self::once())
 			->method('getSentry')
 			->with($sentryIdentificator)
-			->will($this->returnValue(new SimpleType()));
+			->will(self::returnValue(new SimpleType()));
 
 		$annotationProvider = $this->createMock(AnnotationProvider::class);
 		$annotationProvider
-			->expects($this->once())
+			->expects(self::once())
 			->method('getPropertyAnnotation')
-			->with($classReflection->getProperty($propertyName), $this->isType('string'))
-			->will($this->returnValue($sentryIdentificatorAnnotation));
+			->with($classReflection->getProperty($propertyName), Assert::isType('string'))
+			->will(self::returnValue($sentryIdentificatorAnnotation));
 		$annotationProvider
-			->expects($this->exactly(2))
+			->expects(self::exactly(2))
 			->method('getPropertyAnnotations')
-			->will($this->returnCallback($getAnnotationsCallback));
+			->will(self::returnCallback($getAnnotationsCallback));
 
 		$metadataSource = new AnnotationMetadataSource(
 			$sentryFactory,
@@ -134,14 +135,14 @@ class AnnotationMetadataSourceTest extends \PHPUnit\Framework\TestCase
 		);
 		$classMetadata = $metadataSource->getMetadataForClass($classReflection);
 
-		$this->assertSame($className, $classMetadata->getName());
+		Assert::assertSame($className, $classMetadata->getName());
 		$properties = $classMetadata->getProperties();
-		$this->assertCount(1, $properties);
+		Assert::assertCount(1, $properties);
 		$fooProperty = $properties[0];
 		$sentryMethods = $fooProperty->getSentryMethods();
-		$this->assertCount(1, $sentryMethods);
+		Assert::assertCount(1, $sentryMethods);
 		$getMethod = $sentryMethods[0];
-		$this->assertSame('test', $getMethod->getMethodName());
+		Assert::assertSame('test', $getMethod->getMethodName());
 	}
 
 	public function testCustomMethodVisibility(): void
@@ -170,21 +171,21 @@ class AnnotationMetadataSourceTest extends \PHPUnit\Framework\TestCase
 
 		$sentryFactory = $this->createMock(SentryFactory::class);
 		$sentryFactory
-			->expects($this->once())
+			->expects(self::once())
 			->method('getSentry')
 			->with($sentryIdentificator)
-			->will($this->returnValue(new SimpleType()));
+			->will(self::returnValue(new SimpleType()));
 
 		$annotationProvider = $this->createMock(AnnotationProvider::class);
 		$annotationProvider
-			->expects($this->once())
+			->expects(self::once())
 			->method('getPropertyAnnotation')
-			->with($classReflection->getProperty($propertyName), $this->isType('string'))
-			->will($this->returnValue($sentryIdentificatorAnnotation));
+			->with($classReflection->getProperty($propertyName), Assert::isType('string'))
+			->will(self::returnValue($sentryIdentificatorAnnotation));
 		$annotationProvider
-			->expects($this->exactly(2))
+			->expects(self::exactly(2))
 			->method('getPropertyAnnotations')
-			->will($this->returnCallback($getAnnotationsCallback));
+			->will(self::returnCallback($getAnnotationsCallback));
 
 		$metadataSource = new AnnotationMetadataSource(
 			$sentryFactory,
@@ -193,14 +194,14 @@ class AnnotationMetadataSourceTest extends \PHPUnit\Framework\TestCase
 		);
 		$classMetadata = $metadataSource->getMetadataForClass($classReflection);
 
-		$this->assertSame($className, $classMetadata->getName());
+		Assert::assertSame($className, $classMetadata->getName());
 		$properties = $classMetadata->getProperties();
-		$this->assertCount(1, $properties);
+		Assert::assertCount(1, $properties);
 		$fooProperty = $properties[0];
 		$sentryMethods = $fooProperty->getSentryMethods();
-		$this->assertCount(1, $sentryMethods);
+		Assert::assertCount(1, $sentryMethods);
 		$getMethod = $sentryMethods[0];
-		$this->assertSame(Visibility::get(Visibility::VISIBILITY_PRIVATE), $getMethod->getMethodVisibility());
+		Assert::assertSame(Visibility::get(Visibility::VISIBILITY_PRIVATE), $getMethod->getMethodVisibility());
 	}
 
 	public function testGetMultipleMethods(): void
@@ -239,21 +240,21 @@ class AnnotationMetadataSourceTest extends \PHPUnit\Framework\TestCase
 
 		$sentryFactory = $this->createMock(SentryFactory::class);
 		$sentryFactory
-			->expects($this->once())
+			->expects(self::once())
 			->method('getSentry')
 			->with($sentryIdentificator)
-			->will($this->returnValue(new SimpleType()));
+			->will(self::returnValue(new SimpleType()));
 
 		$annotationProvider = $this->createMock(AnnotationProvider::class);
 		$annotationProvider
-			->expects($this->once())
+			->expects(self::once())
 			->method('getPropertyAnnotation')
-			->with($classReflection->getProperty($propertyName), $this->isType('string'))
-			->will($this->returnValue($sentryIdentificatorAnnotation));
+			->with($classReflection->getProperty($propertyName), Assert::isType('string'))
+			->will(self::returnValue($sentryIdentificatorAnnotation));
 		$annotationProvider
-			->expects($this->exactly(2))
+			->expects(self::exactly(2))
 			->method('getPropertyAnnotations')
-			->will($this->returnCallback($getAnnotationsCallback));
+			->will(self::returnCallback($getAnnotationsCallback));
 
 		$metadataSource = new AnnotationMetadataSource(
 			$sentryFactory,
@@ -262,12 +263,12 @@ class AnnotationMetadataSourceTest extends \PHPUnit\Framework\TestCase
 		);
 		$classMetadata = $metadataSource->getMetadataForClass($classReflection);
 
-		$this->assertSame($className, $classMetadata->getName());
+		Assert::assertSame($className, $classMetadata->getName());
 		$properties = $classMetadata->getProperties();
-		$this->assertCount(1, $properties);
+		Assert::assertCount(1, $properties);
 		$fooProperty = $properties[0];
 		$sentryMethods = $fooProperty->getSentryMethods();
-		$this->assertCount(4, $sentryMethods);
+		Assert::assertCount(4, $sentryMethods);
 	}
 
 	public function testClassIsNotSentryAware(): void
@@ -301,10 +302,10 @@ class AnnotationMetadataSourceTest extends \PHPUnit\Framework\TestCase
 
 		$annotationProvider = $this->createMock(AnnotationProvider::class);
 		$annotationProvider
-			->expects($this->once())
+			->expects(self::once())
 			->method('getPropertyAnnotation')
 			->with($classReflection->getProperty('fooProperty'), AnnotationMetadataSource::IDENTIFICATOR_ANNOTATION)
-			->will($this->returnValue($sentryIdentificatorAnnotation));
+			->will(self::returnValue($sentryIdentificatorAnnotation));
 
 		$metadataSource = new AnnotationMetadataSource(
 			$sentryFactory,
@@ -313,7 +314,7 @@ class AnnotationMetadataSourceTest extends \PHPUnit\Framework\TestCase
 		);
 
 		$classMetadata = $metadataSource->getMetadataForClass($classReflection);
-		$this->assertEmpty($classMetadata->getProperties());
+		Assert::assertEmpty($classMetadata->getProperties());
 	}
 
 	public function testMissingSentryIdentificator(): void
@@ -325,10 +326,10 @@ class AnnotationMetadataSourceTest extends \PHPUnit\Framework\TestCase
 
 		$annotationProvider = $this->createMock(AnnotationProvider::class);
 		$annotationProvider
-			->expects($this->once())
+			->expects(self::once())
 			->method('getPropertyAnnotation')
 			->with($propertyReflection, AnnotationMetadataSource::IDENTIFICATOR_ANNOTATION)
-			->will($this->throwException(new \Consistence\Annotation\AnnotationNotFoundException(
+			->will(self::throwException(new \Consistence\Annotation\AnnotationNotFoundException(
 				AnnotationMetadataSource::IDENTIFICATOR_ANNOTATION,
 				$propertyReflection
 			)));
@@ -340,7 +341,7 @@ class AnnotationMetadataSourceTest extends \PHPUnit\Framework\TestCase
 		);
 
 		$classMetadata = $metadataSource->getMetadataForClass($classReflection);
-		$this->assertEmpty($classMetadata->getProperties());
+		Assert::assertEmpty($classMetadata->getProperties());
 	}
 
 	public function testNoSentryFound(): void
@@ -350,10 +351,10 @@ class AnnotationMetadataSourceTest extends \PHPUnit\Framework\TestCase
 
 		$sentryFactory = $this->createMock(SentryFactory::class);
 		$sentryFactory
-			->expects($this->once())
+			->expects(self::once())
 			->method('getSentry')
 			->with($sentryIdentificator)
-			->will($this->throwException(new \Consistence\Sentry\Factory\NoSentryForIdentificatorException($sentryIdentificator)));
+			->will(self::throwException(new \Consistence\Sentry\Factory\NoSentryForIdentificatorException($sentryIdentificator)));
 
 		$sentryIdentificatorAnnotation = Annotation::createAnnotationWithValue(
 			AnnotationMetadataSource::IDENTIFICATOR_ANNOTATION,
@@ -362,10 +363,10 @@ class AnnotationMetadataSourceTest extends \PHPUnit\Framework\TestCase
 
 		$annotationProvider = $this->createMock(AnnotationProvider::class);
 		$annotationProvider
-			->expects($this->once())
+			->expects(self::once())
 			->method('getPropertyAnnotation')
 			->with($classReflection->getProperty('fooProperty'), AnnotationMetadataSource::IDENTIFICATOR_ANNOTATION)
-			->will($this->returnValue($sentryIdentificatorAnnotation));
+			->will(self::returnValue($sentryIdentificatorAnnotation));
 
 		$metadataSource = new AnnotationMetadataSource(
 			$sentryFactory,
@@ -374,7 +375,7 @@ class AnnotationMetadataSourceTest extends \PHPUnit\Framework\TestCase
 		);
 
 		$classMetadata = $metadataSource->getMetadataForClass($classReflection);
-		$this->assertEmpty($classMetadata->getProperties());
+		Assert::assertEmpty($classMetadata->getProperties());
 	}
 
 }

--- a/tests/MetadataSource/Annotation/AnnotationMetadataSourceTest.php
+++ b/tests/MetadataSource/Annotation/AnnotationMetadataSourceTest.php
@@ -283,10 +283,15 @@ class AnnotationMetadataSourceTest extends \PHPUnit\Framework\TestCase
 			$annotationProvider
 		);
 
-		$this->expectException(\Consistence\Sentry\MetadataSource\ClassMetadataCouldNotBeCreatedException::class);
-		$this->expectExceptionMessage('SentryAware');
+		$reflectionClass = new ReflectionClass($this);
 
-		$metadataSource->getMetadataForClass(new ReflectionClass($this));
+		try {
+			$metadataSource->getMetadataForClass($reflectionClass);
+			Assert::fail('Exception expected');
+		} catch (\Consistence\Sentry\MetadataSource\ClassMetadataCouldNotBeCreatedException $e) {
+			Assert::assertSame($reflectionClass, $e->getClassReflection());
+			Assert::assertStringContainsString('SentryAware', $e->getMessage());
+		}
 	}
 
 	public function testInvalidSentryIdentificator(): void

--- a/tests/MetadataSource/Annotation/AnnotationMetadataSourceTest.php
+++ b/tests/MetadataSource/Annotation/AnnotationMetadataSourceTest.php
@@ -70,19 +70,19 @@ class AnnotationMetadataSourceTest extends \PHPUnit\Framework\TestCase
 		$this->assertSame($className, $classMetadata->getName());
 		$properties = $classMetadata->getProperties();
 		$this->assertCount(1, $properties);
-		$fooPropety = $properties[0];
-		$this->assertSame($propertyName, $fooPropety->getName());
-		$this->assertSame($className, $fooPropety->getClassName());
-		$this->assertSame($type, $fooPropety->getType());
-		$this->assertTrue($sentryIdentificator->equals($fooPropety->getSentryIdentificator()));
-		$this->assertFalse($fooPropety->isNullable());
-		$sentryMethods = $fooPropety->getSentryMethods();
+		$fooProperty = $properties[0];
+		$this->assertSame($propertyName, $fooProperty->getName());
+		$this->assertSame($className, $fooProperty->getClassName());
+		$this->assertSame($type, $fooProperty->getType());
+		$this->assertTrue($sentryIdentificator->equals($fooProperty->getSentryIdentificator()));
+		$this->assertFalse($fooProperty->isNullable());
+		$sentryMethods = $fooProperty->getSentryMethods();
 		$this->assertCount(1, $sentryMethods);
 		$getMethod = $sentryMethods[0];
 		$this->assertSame('getFooProperty', $getMethod->getMethodName());
 		$this->assertSame(Visibility::get(Visibility::VISIBILITY_PUBLIC), $getMethod->getMethodVisibility());
 		$this->assertTrue($getMethod->getSentryAccess()->equals(new SentryAccess('get')));
-		$this->assertNull($fooPropety->getBidirectionalAssociation());
+		$this->assertNull($fooProperty->getBidirectionalAssociation());
 	}
 
 	public function testCustomMethodName(): void
@@ -137,8 +137,8 @@ class AnnotationMetadataSourceTest extends \PHPUnit\Framework\TestCase
 		$this->assertSame($className, $classMetadata->getName());
 		$properties = $classMetadata->getProperties();
 		$this->assertCount(1, $properties);
-		$fooPropety = $properties[0];
-		$sentryMethods = $fooPropety->getSentryMethods();
+		$fooProperty = $properties[0];
+		$sentryMethods = $fooProperty->getSentryMethods();
 		$this->assertCount(1, $sentryMethods);
 		$getMethod = $sentryMethods[0];
 		$this->assertSame('test', $getMethod->getMethodName());
@@ -196,8 +196,8 @@ class AnnotationMetadataSourceTest extends \PHPUnit\Framework\TestCase
 		$this->assertSame($className, $classMetadata->getName());
 		$properties = $classMetadata->getProperties();
 		$this->assertCount(1, $properties);
-		$fooPropety = $properties[0];
-		$sentryMethods = $fooPropety->getSentryMethods();
+		$fooProperty = $properties[0];
+		$sentryMethods = $fooProperty->getSentryMethods();
 		$this->assertCount(1, $sentryMethods);
 		$getMethod = $sentryMethods[0];
 		$this->assertSame(Visibility::get(Visibility::VISIBILITY_PRIVATE), $getMethod->getMethodVisibility());
@@ -265,8 +265,8 @@ class AnnotationMetadataSourceTest extends \PHPUnit\Framework\TestCase
 		$this->assertSame($className, $classMetadata->getName());
 		$properties = $classMetadata->getProperties();
 		$this->assertCount(1, $properties);
-		$fooPropety = $properties[0];
-		$sentryMethods = $fooPropety->getSentryMethods();
+		$fooProperty = $properties[0];
+		$sentryMethods = $fooProperty->getSentryMethods();
 		$this->assertCount(4, $sentryMethods);
 	}
 
@@ -276,7 +276,7 @@ class AnnotationMetadataSourceTest extends \PHPUnit\Framework\TestCase
 
 		$annotationProvider = $this->createMock(AnnotationProvider::class);
 
-		$metedataSource = new AnnotationMetadataSource(
+		$metadataSource = new AnnotationMetadataSource(
 			$sentryFactory,
 			new SentryIdentificatorParser(),
 			$annotationProvider
@@ -285,7 +285,7 @@ class AnnotationMetadataSourceTest extends \PHPUnit\Framework\TestCase
 		$this->expectException(\Consistence\Sentry\MetadataSource\ClassMetadataCouldNotBeCreatedException::class);
 		$this->expectExceptionMessage('SentryAware');
 
-		$metedataSource->getMetadataForClass(new ReflectionClass($this));
+		$metadataSource->getMetadataForClass(new ReflectionClass($this));
 	}
 
 	public function testInvalidSentryIdentificator(): void
@@ -306,13 +306,13 @@ class AnnotationMetadataSourceTest extends \PHPUnit\Framework\TestCase
 			->with($classReflection->getProperty('fooProperty'), AnnotationMetadataSource::IDENTIFICATOR_ANNOTATION)
 			->will($this->returnValue($sentryIdentificatorAnnotation));
 
-		$metedataSource = new AnnotationMetadataSource(
+		$metadataSource = new AnnotationMetadataSource(
 			$sentryFactory,
 			new SentryIdentificatorParser(),
 			$annotationProvider
 		);
 
-		$classMetadata = $metedataSource->getMetadataForClass($classReflection);
+		$classMetadata = $metadataSource->getMetadataForClass($classReflection);
 		$this->assertEmpty($classMetadata->getProperties());
 	}
 
@@ -333,13 +333,13 @@ class AnnotationMetadataSourceTest extends \PHPUnit\Framework\TestCase
 				$propertyReflection
 			)));
 
-		$metedataSource = new AnnotationMetadataSource(
+		$metadataSource = new AnnotationMetadataSource(
 			$sentryFactory,
 			new SentryIdentificatorParser(),
 			$annotationProvider
 		);
 
-		$classMetadata = $metedataSource->getMetadataForClass($classReflection);
+		$classMetadata = $metadataSource->getMetadataForClass($classReflection);
 		$this->assertEmpty($classMetadata->getProperties());
 	}
 
@@ -367,13 +367,13 @@ class AnnotationMetadataSourceTest extends \PHPUnit\Framework\TestCase
 			->with($classReflection->getProperty('fooProperty'), AnnotationMetadataSource::IDENTIFICATOR_ANNOTATION)
 			->will($this->returnValue($sentryIdentificatorAnnotation));
 
-		$metedataSource = new AnnotationMetadataSource(
+		$metadataSource = new AnnotationMetadataSource(
 			$sentryFactory,
 			new SentryIdentificatorParser(),
 			$annotationProvider
 		);
 
-		$classMetadata = $metedataSource->getMetadataForClass($classReflection);
+		$classMetadata = $metadataSource->getMetadataForClass($classReflection);
 		$this->assertEmpty($classMetadata->getProperties());
 	}
 

--- a/tests/MetadataSource/MetadataSourceTest.php
+++ b/tests/MetadataSource/MetadataSourceTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Consistence\Sentry\MetadataSource;
 
+use PHPUnit\Framework\Assert;
 use ReflectionClass;
 
 class MetadataSourceTest extends \PHPUnit\Framework\TestCase
@@ -13,7 +14,7 @@ class MetadataSourceTest extends \PHPUnit\Framework\TestCase
 	{
 		$factory = $this->createMock(MetadataSource::class);
 		$factory
-			->expects($this->once())
+			->expects(self::once())
 			->method('getMetadataForClass');
 
 		$factory->getMetadataForClass(new ReflectionClass(FooClass::class));
@@ -24,17 +25,17 @@ class MetadataSourceTest extends \PHPUnit\Framework\TestCase
 		$classReflection = new ReflectionClass(FooClass::class);
 		$factory = $this->createMock(MetadataSource::class);
 		$factory
-			->expects($this->once())
+			->expects(self::once())
 			->method('getMetadataForClass')
-			->will($this->throwException(new \Consistence\Sentry\MetadataSource\ClassMetadataCouldNotBeCreatedException($classReflection, 'test')));
+			->will(self::throwException(new \Consistence\Sentry\MetadataSource\ClassMetadataCouldNotBeCreatedException($classReflection, 'test')));
 
 		try {
 			$factory->getMetadataForClass($classReflection);
-			$this->fail();
+			Assert::fail();
 		} catch (\Consistence\Sentry\MetadataSource\ClassMetadataCouldNotBeCreatedException $e) {
-			$this->assertSame($classReflection, $e->getClassReflection());
-			$this->assertStringContainsString(FooClass::class, $e->getMessage());
-			$this->assertStringContainsString('test', $e->getMessage());
+			Assert::assertSame($classReflection, $e->getClassReflection());
+			Assert::assertStringContainsString(FooClass::class, $e->getMessage());
+			Assert::assertStringContainsString('test', $e->getMessage());
 		}
 	}
 

--- a/tests/MetadataSource/MetadataSourceTest.php
+++ b/tests/MetadataSource/MetadataSourceTest.php
@@ -31,7 +31,7 @@ class MetadataSourceTest extends \PHPUnit\Framework\TestCase
 
 		try {
 			$factory->getMetadataForClass($classReflection);
-			Assert::fail();
+			Assert::fail('Exception expected');
 		} catch (\Consistence\Sentry\MetadataSource\ClassMetadataCouldNotBeCreatedException $e) {
 			Assert::assertSame($classReflection, $e->getClassReflection());
 			Assert::assertStringContainsString(FooClass::class, $e->getMessage());

--- a/tests/SentryIdentificatorParser/SentryIdentificatorParserTest.php
+++ b/tests/SentryIdentificatorParser/SentryIdentificatorParserTest.php
@@ -17,144 +17,144 @@ class SentryIdentificatorParserTest extends \PHPUnit\Framework\TestCase
 	public function matchesDataProvider(): Generator
 	{
 		yield [
-			new SentryIdentificator('string'),
-			'string',
-			false,
-			false,
-			null,
+			'sentryIdentificator' => new SentryIdentificator('string'),
+			'expectedType' => 'string',
+			'expectedMany' => false,
+			'expectedNullable' => false,
+			'sourceClass' => null,
 		];
 		yield [
-			new SentryIdentificator('string[]'),
-			'string',
-			true,
-			false,
-			null,
+			'sentryIdentificator' => new SentryIdentificator('string[]'),
+			'expectedType' => 'string',
+			'expectedMany' => true,
+			'expectedNullable' => false,
+			'sourceClass' => null,
 		];
 		yield [
-			new SentryIdentificator('string|NULL'),
-			'string',
-			false,
-			true,
-			null,
+			'sentryIdentificator' => new SentryIdentificator('string|NULL'),
+			'expectedType' => 'string',
+			'expectedMany' => false,
+			'expectedNullable' => true,
+			'sourceClass' => null,
 		];
 		yield [
-			new SentryIdentificator('string|null'),
-			'string',
-			false,
-			true,
-			null,
+			'sentryIdentificator' => new SentryIdentificator('string|null'),
+			'expectedType' => 'string',
+			'expectedMany' => false,
+			'expectedNullable' => true,
+			'sourceClass' => null,
 		];
 		yield [
-			new SentryIdentificator('string[]|NULL'),
-			'string',
-			true,
-			true,
-			null,
+			'sentryIdentificator' => new SentryIdentificator('string[]|NULL'),
+			'expectedType' => 'string',
+			'expectedMany' => true,
+			'expectedNullable' => true,
+			'sourceClass' => null,
 		];
 		yield [
-			new SentryIdentificator('string[]|null'),
-			'string',
-			true,
-			true,
-			null,
+			'sentryIdentificator' => new SentryIdentificator('string[]|null'),
+			'expectedType' => 'string',
+			'expectedMany' => true,
+			'expectedNullable' => true,
+			'sourceClass' => null,
 		];
 		yield [
-			new SentryIdentificator('string[][]'),
-			'string',
-			true,
-			false,
-			null,
+			'sentryIdentificator' => new SentryIdentificator('string[][]'),
+			'expectedType' => 'string',
+			'expectedMany' => true,
+			'expectedNullable' => false,
+			'sourceClass' => null,
 		];
 		yield [
-			new SentryIdentificator('string[][]|null'),
-			'string',
-			true,
-			true,
-			null,
+			'sentryIdentificator' => new SentryIdentificator('string[][]|null'),
+			'expectedType' => 'string',
+			'expectedMany' => true,
+			'expectedNullable' => true,
+			'sourceClass' => null,
 		];
 		yield [
-			new SentryIdentificator('Foo'),
-			'Foo',
-			false,
-			false,
-			null,
+			'sentryIdentificator' => new SentryIdentificator('Foo'),
+			'expectedType' => 'Foo',
+			'expectedMany' => false,
+			'expectedNullable' => false,
+			'sourceClass' => null,
 		];
 		yield [
-			new SentryIdentificator('\Foo'),
-			'Foo',
-			false,
-			false,
-			null,
+			'sentryIdentificator' => new SentryIdentificator('\Foo'),
+			'expectedType' => 'Foo',
+			'expectedMany' => false,
+			'expectedNullable' => false,
+			'sourceClass' => null,
 		];
 		yield [
-			new SentryIdentificator('Foo\Bar'),
-			'Foo\Bar',
-			false,
-			false,
-			null,
+			'sentryIdentificator' => new SentryIdentificator('Foo\Bar'),
+			'expectedType' => 'Foo\Bar',
+			'expectedMany' => false,
+			'expectedNullable' => false,
+			'sourceClass' => null,
 		];
 		yield [
-			new SentryIdentificator('\Foo\Bar'),
-			'Foo\Bar',
-			false,
-			false,
-			null,
+			'sentryIdentificator' => new SentryIdentificator('\Foo\Bar'),
+			'expectedType' => 'Foo\Bar',
+			'expectedMany' => false,
+			'expectedNullable' => false,
+			'sourceClass' => null,
 		];
 		yield [
-			new SentryIdentificator('\Foo\Bar[]'),
-			'Foo\Bar',
-			true,
-			false,
-			null,
+			'sentryIdentificator' => new SentryIdentificator('\Foo\Bar[]'),
+			'expectedType' => 'Foo\Bar',
+			'expectedMany' => true,
+			'expectedNullable' => false,
+			'sourceClass' => null,
 		];
 		yield [
-			new SentryIdentificator('\Foo\Bar[]|null'),
-			'Foo\Bar',
-			true,
-			true,
-			null,
+			'sentryIdentificator' => new SentryIdentificator('\Foo\Bar[]|null'),
+			'expectedType' => 'Foo\Bar',
+			'expectedMany' => true,
+			'expectedNullable' => true,
+			'sourceClass' => null,
 		];
 		yield [
-			new SentryIdentificator('\Foo\Bar foobar'),
-			'Foo\Bar',
-			false,
-			false,
-			null,
+			'sentryIdentificator' => new SentryIdentificator('\Foo\Bar foobar'),
+			'expectedType' => 'Foo\Bar',
+			'expectedMany' => false,
+			'expectedNullable' => false,
+			'sourceClass' => null,
 		];
 		yield [
-			new SentryIdentificator('\Foo\Bar nullable'),
-			'Foo\Bar',
-			false,
-			false,
-			null,
+			'sentryIdentificator' => new SentryIdentificator('\Foo\Bar nullable'),
+			'expectedType' => 'Foo\Bar',
+			'expectedMany' => false,
+			'expectedNullable' => false,
+			'sourceClass' => null,
 		];
 		yield [
-			new SentryIdentificator('\Collection of \Foo\Bar'),
-			'Collection',
-			false,
-			false,
-			null,
+			'sentryIdentificator' => new SentryIdentificator('\Collection of \Foo\Bar'),
+			'expectedType' => 'Collection',
+			'expectedMany' => false,
+			'expectedNullable' => false,
+			'sourceClass' => null,
 		];
 		yield [
-			new SentryIdentificator('Foo::Bar'),
-			'Bar',
-			false,
-			false,
-			'Foo',
+			'sentryIdentificator' => new SentryIdentificator('Foo::Bar'),
+			'expectedType' => 'Bar',
+			'expectedMany' => false,
+			'expectedNullable' => false,
+			'sourceClass' => 'Foo',
 		];
 		yield [
-			new SentryIdentificator('\Foo::\Bar'),
-			'Bar',
-			false,
-			false,
-			'Foo',
+			'sentryIdentificator' => new SentryIdentificator('\Foo::\Bar'),
+			'expectedType' => 'Bar',
+			'expectedMany' => false,
+			'expectedNullable' => false,
+			'sourceClass' => 'Foo',
 		];
 		yield [
-			new SentryIdentificator('Long\Class\Name\Which\Tests\The\Backtracking\Limit::Bar'),
-			'Bar',
-			false,
-			false,
-			'Long\Class\Name\Which\Tests\The\Backtracking\Limit',
+			'sentryIdentificator' => new SentryIdentificator('Long\Class\Name\Which\Tests\The\Backtracking\Limit::Bar'),
+			'expectedType' => 'Bar',
+			'expectedMany' => false,
+			'expectedNullable' => false,
+			'sourceClass' => 'Long\Class\Name\Which\Tests\The\Backtracking\Limit',
 		];
 	}
 
@@ -164,10 +164,10 @@ class SentryIdentificatorParserTest extends \PHPUnit\Framework\TestCase
 	public function doesNotMatchDataProvider(): Generator
 	{
 		yield [
-			'',
+			'pattern' => '',
 		];
 		yield [
-			'Long\Class\Name\Which\Tests\The\Backtracking\Limit::',
+			'pattern' => 'Long\Class\Name\Which\Tests\The\Backtracking\Limit::',
 		];
 	}
 

--- a/tests/SentryIdentificatorParser/SentryIdentificatorParserTest.php
+++ b/tests/SentryIdentificatorParser/SentryIdentificatorParserTest.php
@@ -16,26 +16,146 @@ class SentryIdentificatorParserTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function matchesDataProvider(): Generator
 	{
-		yield [new SentryIdentificator('string'), 'string', false, false, null];
-		yield [new SentryIdentificator('string[]'), 'string', true, false, null];
-		yield [new SentryIdentificator('string|NULL'), 'string', false, true, null];
-		yield [new SentryIdentificator('string|null'), 'string', false, true, null];
-		yield [new SentryIdentificator('string[]|NULL'), 'string', true, true, null];
-		yield [new SentryIdentificator('string[]|null'), 'string', true, true, null];
-		yield [new SentryIdentificator('string[][]'), 'string', true, false, null];
-		yield [new SentryIdentificator('string[][]|null'), 'string', true, true, null];
-		yield [new SentryIdentificator('Foo'), 'Foo', false, false, null];
-		yield [new SentryIdentificator('\Foo'), 'Foo', false, false, null];
-		yield [new SentryIdentificator('Foo\Bar'), 'Foo\Bar', false, false, null];
-		yield [new SentryIdentificator('\Foo\Bar'), 'Foo\Bar', false, false, null];
-		yield [new SentryIdentificator('\Foo\Bar[]'), 'Foo\Bar', true, false, null];
-		yield [new SentryIdentificator('\Foo\Bar[]|null'), 'Foo\Bar', true, true, null];
-		yield [new SentryIdentificator('\Foo\Bar foobar'), 'Foo\Bar', false, false, null];
-		yield [new SentryIdentificator('\Foo\Bar nullable'), 'Foo\Bar', false, false, null];
-		yield [new SentryIdentificator('\Collection of \Foo\Bar'), 'Collection', false, false, null];
-		yield [new SentryIdentificator('Foo::Bar'), 'Bar', false, false, 'Foo'];
-		yield [new SentryIdentificator('\Foo::\Bar'), 'Bar', false, false, 'Foo'];
-		yield [new SentryIdentificator('Long\Class\Name\Which\Tests\The\Backtracking\Limit::Bar'), 'Bar', false, false, 'Long\Class\Name\Which\Tests\The\Backtracking\Limit'];
+		yield [
+			new SentryIdentificator('string'),
+			'string',
+			false,
+			false,
+			null,
+		];
+		yield [
+			new SentryIdentificator('string[]'),
+			'string',
+			true,
+			false,
+			null,
+		];
+		yield [
+			new SentryIdentificator('string|NULL'),
+			'string',
+			false,
+			true,
+			null,
+		];
+		yield [
+			new SentryIdentificator('string|null'),
+			'string',
+			false,
+			true,
+			null,
+		];
+		yield [
+			new SentryIdentificator('string[]|NULL'),
+			'string',
+			true,
+			true,
+			null,
+		];
+		yield [
+			new SentryIdentificator('string[]|null'),
+			'string',
+			true,
+			true,
+			null,
+		];
+		yield [
+			new SentryIdentificator('string[][]'),
+			'string',
+			true,
+			false,
+			null,
+		];
+		yield [
+			new SentryIdentificator('string[][]|null'),
+			'string',
+			true,
+			true,
+			null,
+		];
+		yield [
+			new SentryIdentificator('Foo'),
+			'Foo',
+			false,
+			false,
+			null,
+		];
+		yield [
+			new SentryIdentificator('\Foo'),
+			'Foo',
+			false,
+			false,
+			null,
+		];
+		yield [
+			new SentryIdentificator('Foo\Bar'),
+			'Foo\Bar',
+			false,
+			false,
+			null,
+		];
+		yield [
+			new SentryIdentificator('\Foo\Bar'),
+			'Foo\Bar',
+			false,
+			false,
+			null,
+		];
+		yield [
+			new SentryIdentificator('\Foo\Bar[]'),
+			'Foo\Bar',
+			true,
+			false,
+			null,
+		];
+		yield [
+			new SentryIdentificator('\Foo\Bar[]|null'),
+			'Foo\Bar',
+			true,
+			true,
+			null,
+		];
+		yield [
+			new SentryIdentificator('\Foo\Bar foobar'),
+			'Foo\Bar',
+			false,
+			false,
+			null,
+		];
+		yield [
+			new SentryIdentificator('\Foo\Bar nullable'),
+			'Foo\Bar',
+			false,
+			false,
+			null,
+		];
+		yield [
+			new SentryIdentificator('\Collection of \Foo\Bar'),
+			'Collection',
+			false,
+			false,
+			null,
+		];
+		yield [
+			new SentryIdentificator('Foo::Bar'),
+			'Bar',
+			false,
+			false,
+			'Foo',
+		];
+		yield [
+			new SentryIdentificator('\Foo::\Bar'),
+			'Bar',
+			false,
+			false,
+			'Foo',
+		];
+		yield [
+			new SentryIdentificator('Long\Class\Name\Which\Tests\The\Backtracking\Limit::Bar'),
+			'Bar',
+			false,
+			false,
+			'Long\Class\Name\Which\Tests\The\Backtracking\Limit',
+		];
 	}
 
 	/**
@@ -43,8 +163,12 @@ class SentryIdentificatorParserTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function doesNotMatchDataProvider(): Generator
 	{
-		yield [''];
-		yield ['Long\Class\Name\Which\Tests\The\Backtracking\Limit::'];
+		yield [
+			'',
+		];
+		yield [
+			'Long\Class\Name\Which\Tests\The\Backtracking\Limit::',
+		];
 	}
 
 	/**

--- a/tests/SentryIdentificatorParser/SentryIdentificatorParserTest.php
+++ b/tests/SentryIdentificatorParser/SentryIdentificatorParserTest.php
@@ -5,49 +5,46 @@ declare(strict_types = 1);
 namespace Consistence\Sentry\SentryIdentificatorParser;
 
 use Consistence\Sentry\Metadata\SentryIdentificator;
+use Generator;
 use PHPUnit\Framework\Assert;
 
 class SentryIdentificatorParserTest extends \PHPUnit\Framework\TestCase
 {
 
 	/**
-	 * @return mixed[][]
+	 * @return mixed[][]|\Generator
 	 */
-	public function matchesDataProvider(): array
+	public function matchesDataProvider(): Generator
 	{
-		return [
-			[new SentryIdentificator('string'), 'string', false, false, null],
-			[new SentryIdentificator('string[]'), 'string', true, false, null],
-			[new SentryIdentificator('string|NULL'), 'string', false, true, null],
-			[new SentryIdentificator('string|null'), 'string', false, true, null],
-			[new SentryIdentificator('string[]|NULL'), 'string', true, true, null],
-			[new SentryIdentificator('string[]|null'), 'string', true, true, null],
-			[new SentryIdentificator('string[][]'), 'string', true, false, null],
-			[new SentryIdentificator('string[][]|null'), 'string', true, true, null],
-			[new SentryIdentificator('Foo'), 'Foo', false, false, null],
-			[new SentryIdentificator('\Foo'), 'Foo', false, false, null],
-			[new SentryIdentificator('Foo\Bar'), 'Foo\Bar', false, false, null],
-			[new SentryIdentificator('\Foo\Bar'), 'Foo\Bar', false, false, null],
-			[new SentryIdentificator('\Foo\Bar[]'), 'Foo\Bar', true, false, null],
-			[new SentryIdentificator('\Foo\Bar[]|null'), 'Foo\Bar', true, true, null],
-			[new SentryIdentificator('\Foo\Bar foobar'), 'Foo\Bar', false, false, null],
-			[new SentryIdentificator('\Foo\Bar nullable'), 'Foo\Bar', false, false, null],
-			[new SentryIdentificator('\Collection of \Foo\Bar'), 'Collection', false, false, null],
-			[new SentryIdentificator('Foo::Bar'), 'Bar', false, false, 'Foo'],
-			[new SentryIdentificator('\Foo::\Bar'), 'Bar', false, false, 'Foo'],
-			[new SentryIdentificator('Long\Class\Name\Which\Tests\The\Backtracking\Limit::Bar'), 'Bar', false, false, 'Long\Class\Name\Which\Tests\The\Backtracking\Limit'],
-		];
+		yield [new SentryIdentificator('string'), 'string', false, false, null];
+		yield [new SentryIdentificator('string[]'), 'string', true, false, null];
+		yield [new SentryIdentificator('string|NULL'), 'string', false, true, null];
+		yield [new SentryIdentificator('string|null'), 'string', false, true, null];
+		yield [new SentryIdentificator('string[]|NULL'), 'string', true, true, null];
+		yield [new SentryIdentificator('string[]|null'), 'string', true, true, null];
+		yield [new SentryIdentificator('string[][]'), 'string', true, false, null];
+		yield [new SentryIdentificator('string[][]|null'), 'string', true, true, null];
+		yield [new SentryIdentificator('Foo'), 'Foo', false, false, null];
+		yield [new SentryIdentificator('\Foo'), 'Foo', false, false, null];
+		yield [new SentryIdentificator('Foo\Bar'), 'Foo\Bar', false, false, null];
+		yield [new SentryIdentificator('\Foo\Bar'), 'Foo\Bar', false, false, null];
+		yield [new SentryIdentificator('\Foo\Bar[]'), 'Foo\Bar', true, false, null];
+		yield [new SentryIdentificator('\Foo\Bar[]|null'), 'Foo\Bar', true, true, null];
+		yield [new SentryIdentificator('\Foo\Bar foobar'), 'Foo\Bar', false, false, null];
+		yield [new SentryIdentificator('\Foo\Bar nullable'), 'Foo\Bar', false, false, null];
+		yield [new SentryIdentificator('\Collection of \Foo\Bar'), 'Collection', false, false, null];
+		yield [new SentryIdentificator('Foo::Bar'), 'Bar', false, false, 'Foo'];
+		yield [new SentryIdentificator('\Foo::\Bar'), 'Bar', false, false, 'Foo'];
+		yield [new SentryIdentificator('Long\Class\Name\Which\Tests\The\Backtracking\Limit::Bar'), 'Bar', false, false, 'Long\Class\Name\Which\Tests\The\Backtracking\Limit'];
 	}
 
 	/**
-	 * @return string[][]
+	 * @return string[][]|\Generator
 	 */
-	public function doesNotMatchDataProvider(): array
+	public function doesNotMatchDataProvider(): Generator
 	{
-		return [
-			[''],
-			['Long\Class\Name\Which\Tests\The\Backtracking\Limit::'],
-		];
+		yield [''];
+		yield ['Long\Class\Name\Which\Tests\The\Backtracking\Limit::'];
 	}
 
 	/**

--- a/tests/SentryIdentificatorParser/SentryIdentificatorParserTest.php
+++ b/tests/SentryIdentificatorParser/SentryIdentificatorParserTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Consistence\Sentry\SentryIdentificatorParser;
 
 use Consistence\Sentry\Metadata\SentryIdentificator;
+use PHPUnit\Framework\Assert;
 
 class SentryIdentificatorParserTest extends \PHPUnit\Framework\TestCase
 {
@@ -68,12 +69,12 @@ class SentryIdentificatorParserTest extends \PHPUnit\Framework\TestCase
 	{
 		$parser = new SentryIdentificatorParser();
 		$result = $parser->parse($sentryIdentificator);
-		$this->assertInstanceOf(SentryIdentificatorParseResult::class, $result);
-		$this->assertSame($sentryIdentificator, $result->getSentryIdentificator());
-		$this->assertSame($expectedType, $result->getType());
-		$this->assertSame($expectedMany, $result->isMany());
-		$this->assertSame($expectedNullable, $result->isNullable());
-		$this->assertSame($sourceClass, $result->getSourceClass());
+		Assert::assertInstanceOf(SentryIdentificatorParseResult::class, $result);
+		Assert::assertSame($sentryIdentificator, $result->getSentryIdentificator());
+		Assert::assertSame($expectedType, $result->getType());
+		Assert::assertSame($expectedMany, $result->isMany());
+		Assert::assertSame($expectedNullable, $result->isNullable());
+		Assert::assertSame($sourceClass, $result->getSourceClass());
 	}
 
 	/**
@@ -87,9 +88,9 @@ class SentryIdentificatorParserTest extends \PHPUnit\Framework\TestCase
 		$sentryIdentificator = new SentryIdentificator($pattern);
 		try {
 			$parser->parse($sentryIdentificator);
-			$this->fail();
+			Assert::fail();
 		} catch (\Consistence\Sentry\SentryIdentificatorParser\PatternDoesNotMatchException $e) {
-			$this->assertSame($sentryIdentificator, $e->getSentryIdentificator());
+			Assert::assertSame($sentryIdentificator, $e->getSentryIdentificator());
 		}
 	}
 

--- a/tests/SentryIdentificatorParser/SentryIdentificatorParserTest.php
+++ b/tests/SentryIdentificatorParser/SentryIdentificatorParserTest.php
@@ -16,140 +16,140 @@ class SentryIdentificatorParserTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function matchesDataProvider(): Generator
 	{
-		yield [
+		yield 'string' => [
 			'sentryIdentificator' => new SentryIdentificator('string'),
 			'expectedType' => 'string',
 			'expectedMany' => false,
 			'expectedNullable' => false,
 			'sourceClass' => null,
 		];
-		yield [
+		yield 'array of strings' => [
 			'sentryIdentificator' => new SentryIdentificator('string[]'),
 			'expectedType' => 'string',
 			'expectedMany' => true,
 			'expectedNullable' => false,
 			'sourceClass' => null,
 		];
-		yield [
+		yield 'nullable string, uppercase NULL' => [
 			'sentryIdentificator' => new SentryIdentificator('string|NULL'),
 			'expectedType' => 'string',
 			'expectedMany' => false,
 			'expectedNullable' => true,
 			'sourceClass' => null,
 		];
-		yield [
+		yield 'nullable string, lowercase null' => [
 			'sentryIdentificator' => new SentryIdentificator('string|null'),
 			'expectedType' => 'string',
 			'expectedMany' => false,
 			'expectedNullable' => true,
 			'sourceClass' => null,
 		];
-		yield [
+		yield 'nullable array of strings, uppercase NULL' => [
 			'sentryIdentificator' => new SentryIdentificator('string[]|NULL'),
 			'expectedType' => 'string',
 			'expectedMany' => true,
 			'expectedNullable' => true,
 			'sourceClass' => null,
 		];
-		yield [
+		yield 'nullable array of strings, lowercase null' => [
 			'sentryIdentificator' => new SentryIdentificator('string[]|null'),
 			'expectedType' => 'string',
 			'expectedMany' => true,
 			'expectedNullable' => true,
 			'sourceClass' => null,
 		];
-		yield [
+		yield 'two-dimensional array of strings' => [
 			'sentryIdentificator' => new SentryIdentificator('string[][]'),
 			'expectedType' => 'string',
 			'expectedMany' => true,
 			'expectedNullable' => false,
 			'sourceClass' => null,
 		];
-		yield [
+		yield 'nullable two-dimensional array of strings, lowercase null' => [
 			'sentryIdentificator' => new SentryIdentificator('string[][]|null'),
 			'expectedType' => 'string',
 			'expectedMany' => true,
 			'expectedNullable' => true,
 			'sourceClass' => null,
 		];
-		yield [
+		yield 'object of class without leading backslash' => [
 			'sentryIdentificator' => new SentryIdentificator('Foo'),
 			'expectedType' => 'Foo',
 			'expectedMany' => false,
 			'expectedNullable' => false,
 			'sourceClass' => null,
 		];
-		yield [
+		yield 'object of class with leading backslash' => [
 			'sentryIdentificator' => new SentryIdentificator('\Foo'),
 			'expectedType' => 'Foo',
 			'expectedMany' => false,
 			'expectedNullable' => false,
 			'sourceClass' => null,
 		];
-		yield [
+		yield 'object of namespaced class without leading backslash' => [
 			'sentryIdentificator' => new SentryIdentificator('Foo\Bar'),
 			'expectedType' => 'Foo\Bar',
 			'expectedMany' => false,
 			'expectedNullable' => false,
 			'sourceClass' => null,
 		];
-		yield [
+		yield 'object of namespaced class with leading backslash' => [
 			'sentryIdentificator' => new SentryIdentificator('\Foo\Bar'),
 			'expectedType' => 'Foo\Bar',
 			'expectedMany' => false,
 			'expectedNullable' => false,
 			'sourceClass' => null,
 		];
-		yield [
+		yield 'array of objects of namespaced class with leading backslash' => [
 			'sentryIdentificator' => new SentryIdentificator('\Foo\Bar[]'),
 			'expectedType' => 'Foo\Bar',
 			'expectedMany' => true,
 			'expectedNullable' => false,
 			'sourceClass' => null,
 		];
-		yield [
+		yield 'nullable array of objects of namespaced class with leading backslash, lowercase null' => [
 			'sentryIdentificator' => new SentryIdentificator('\Foo\Bar[]|null'),
 			'expectedType' => 'Foo\Bar',
 			'expectedMany' => true,
 			'expectedNullable' => true,
 			'sourceClass' => null,
 		];
-		yield [
+		yield 'object of namespaced class with leading backslash followed by name' => [
 			'sentryIdentificator' => new SentryIdentificator('\Foo\Bar foobar'),
 			'expectedType' => 'Foo\Bar',
 			'expectedMany' => false,
 			'expectedNullable' => false,
 			'sourceClass' => null,
 		];
-		yield [
+		yield 'object of namespaced class with leading backslash followed by nullable keyword' => [
 			'sentryIdentificator' => new SentryIdentificator('\Foo\Bar nullable'),
 			'expectedType' => 'Foo\Bar',
 			'expectedMany' => false,
 			'expectedNullable' => false,
 			'sourceClass' => null,
 		];
-		yield [
+		yield 'object of Collection class with leading backslash followed by elements type' => [
 			'sentryIdentificator' => new SentryIdentificator('\Collection of \Foo\Bar'),
 			'expectedType' => 'Collection',
 			'expectedMany' => false,
 			'expectedNullable' => false,
 			'sourceClass' => null,
 		];
-		yield [
+		yield 'object of class with source class, both without leading backslash' => [
 			'sentryIdentificator' => new SentryIdentificator('Foo::Bar'),
 			'expectedType' => 'Bar',
 			'expectedMany' => false,
 			'expectedNullable' => false,
 			'sourceClass' => 'Foo',
 		];
-		yield [
+		yield 'object of class with source class, both with leading backslash' => [
 			'sentryIdentificator' => new SentryIdentificator('\Foo::\Bar'),
 			'expectedType' => 'Bar',
 			'expectedMany' => false,
 			'expectedNullable' => false,
 			'sourceClass' => 'Foo',
 		];
-		yield [
+		yield 'object of class with namespaced source class, both without leading backslash' => [
 			'sentryIdentificator' => new SentryIdentificator('Long\Class\Name\Which\Tests\The\Backtracking\Limit::Bar'),
 			'expectedType' => 'Bar',
 			'expectedMany' => false,
@@ -163,10 +163,10 @@ class SentryIdentificatorParserTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function doesNotMatchDataProvider(): Generator
 	{
-		yield [
+		yield 'empty string' => [
 			'pattern' => '',
 		];
-		yield [
+		yield 'namespaced source class without object' => [
 			'pattern' => 'Long\Class\Name\Which\Tests\The\Backtracking\Limit::',
 		];
 	}

--- a/tests/SentryIdentificatorParser/SentryIdentificatorParserTest.php
+++ b/tests/SentryIdentificatorParser/SentryIdentificatorParserTest.php
@@ -88,7 +88,7 @@ class SentryIdentificatorParserTest extends \PHPUnit\Framework\TestCase
 		$sentryIdentificator = new SentryIdentificator($pattern);
 		try {
 			$parser->parse($sentryIdentificator);
-			Assert::fail();
+			Assert::fail('Exception expected');
 		} catch (\Consistence\Sentry\SentryIdentificatorParser\PatternDoesNotMatchException $e) {
 			Assert::assertSame($sentryIdentificator, $e->getSentryIdentificator());
 		}

--- a/tests/SentryIdentificatorParser/SentryIdentificatorParserTest.php
+++ b/tests/SentryIdentificatorParser/SentryIdentificatorParserTest.php
@@ -13,7 +13,7 @@ class SentryIdentificatorParserTest extends \PHPUnit\Framework\TestCase
 	/**
 	 * @return mixed[][]
 	 */
-	public function matchesProvider(): array
+	public function matchesDataProvider(): array
 	{
 		return [
 			[new SentryIdentificator('string'), 'string', false, false, null],
@@ -42,7 +42,7 @@ class SentryIdentificatorParserTest extends \PHPUnit\Framework\TestCase
 	/**
 	 * @return string[][]
 	 */
-	public function doesNotMatchProvider(): array
+	public function doesNotMatchDataProvider(): array
 	{
 		return [
 			[''],
@@ -51,7 +51,7 @@ class SentryIdentificatorParserTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider matchesProvider
+	 * @dataProvider matchesDataProvider
 	 *
 	 * @param \Consistence\Sentry\Metadata\SentryIdentificator $sentryIdentificator
 	 * @param string $expectedType
@@ -78,7 +78,7 @@ class SentryIdentificatorParserTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider doesNotMatchProvider
+	 * @dataProvider doesNotMatchDataProvider
 	 *
 	 * @param string $pattern
 	 */

--- a/tests/Type/AbstractSentryTest.php
+++ b/tests/Type/AbstractSentryTest.php
@@ -86,27 +86,32 @@ class AbstractSentryTest extends \PHPUnit\Framework\TestCase
 		));
 	}
 
-	public function testGenerateGet(): void
+	/**
+	 * @return mixed[][]|\Generator
+	 */
+	public function generateMethodDataProvider(): Generator
 	{
-		$sentry = $this->getMockForAbstractClass(AbstractSentry::class);
-		$getMethod = new SentryMethod(
-			new SentryAccess('get'),
-			'getFoo',
-			Visibility::get(Visibility::VISIBILITY_PUBLIC)
-		);
-		$propertyMetadata = new PropertyMetadata(
-			'fooProperty',
-			FooClass::class,
-			'int',
-			new SentryIdentificator('int'),
-			false,
-			[
-				$getMethod,
-			],
-			null
-		);
+		yield 'get scalar' => (function (): array {
+			$sentryMethod = new SentryMethod(
+				new SentryAccess('get'),
+				'getFoo',
+				Visibility::get(Visibility::VISIBILITY_PUBLIC)
+			);
 
-		$method = '
+			return [
+				'propertyMetadata' => new PropertyMetadata(
+					'fooProperty',
+					FooClass::class,
+					'int',
+					new SentryIdentificator('int'),
+					false,
+					[
+						$sentryMethod,
+					],
+					null
+				),
+				'sentryMethod' => $sentryMethod,
+				'expectedGeneratedMethod' => '
 	/**
 	 * Generated int getter
 	 *
@@ -115,31 +120,31 @@ class AbstractSentryTest extends \PHPUnit\Framework\TestCase
 	public function getFoo()
 	{
 		return $this->fooProperty;
-	}';
-		Assert::assertSame($method, $sentry->generateMethod($propertyMetadata, $getMethod));
-	}
+	}',
+			];
+		})();
 
-	public function testGenerateObjectGet(): void
-	{
-		$sentry = $this->getMockForAbstractClass(AbstractSentry::class);
-		$getMethod = new SentryMethod(
-			new SentryAccess('get'),
-			'getFoo',
-			Visibility::get(Visibility::VISIBILITY_PUBLIC)
-		);
-		$propertyMetadata = new PropertyMetadata(
-			'fooProperty',
-			FooClass::class,
-			'stdClass',
-			new SentryIdentificator('stdClass'),
-			false,
-			[
-				$getMethod,
-			],
-			null
-		);
+		yield 'get object' => (function (): array {
+			$sentryMethod = new SentryMethod(
+				new SentryAccess('get'),
+				'getFoo',
+				Visibility::get(Visibility::VISIBILITY_PUBLIC)
+			);
 
-		$method = '
+			return [
+				'propertyMetadata' => new PropertyMetadata(
+					'fooProperty',
+					FooClass::class,
+					'stdClass',
+					new SentryIdentificator('stdClass'),
+					false,
+					[
+						$sentryMethod,
+					],
+					null
+				),
+				'sentryMethod' => $sentryMethod,
+				'expectedGeneratedMethod' => '
 	/**
 	 * Generated stdClass getter
 	 *
@@ -148,31 +153,31 @@ class AbstractSentryTest extends \PHPUnit\Framework\TestCase
 	public function getFoo()
 	{
 		return $this->fooProperty;
-	}';
-		Assert::assertSame($method, $sentry->generateMethod($propertyMetadata, $getMethod));
-	}
+	}',
+			];
+		})();
 
-	public function testGenerateSet(): void
-	{
-		$sentry = $this->getMockForAbstractClass(AbstractSentry::class);
-		$setMethod = new SentryMethod(
-			new SentryAccess('set'),
-			'setFoo',
-			Visibility::get(Visibility::VISIBILITY_PUBLIC)
-		);
-		$propertyMetadata = new PropertyMetadata(
-			'fooProperty',
-			FooClass::class,
-			'int',
-			new SentryIdentificator('int'),
-			false,
-			[
-				$setMethod,
-			],
-			null
-		);
+		yield 'set scalar' => (function (): array {
+			$sentryMethod = new SentryMethod(
+				new SentryAccess('set'),
+				'setFoo',
+				Visibility::get(Visibility::VISIBILITY_PUBLIC)
+			);
 
-		$method = '
+			return [
+				'propertyMetadata' => new PropertyMetadata(
+					'fooProperty',
+					FooClass::class,
+					'int',
+					new SentryIdentificator('int'),
+					false,
+					[
+						$sentryMethod,
+					],
+					null
+				),
+				'sentryMethod' => $sentryMethod,
+				'expectedGeneratedMethod' => '
 	/**
 	 * Generated int setter
 	 *
@@ -181,31 +186,31 @@ class AbstractSentryTest extends \PHPUnit\Framework\TestCase
 	public function setFoo($newValue)
 	{
 		$this->fooProperty = $newValue;
-	}';
-		Assert::assertSame($method, $sentry->generateMethod($propertyMetadata, $setMethod));
-	}
+	}',
+			];
+		})();
 
-	public function testGenerateObjectSet(): void
-	{
-		$sentry = $this->getMockForAbstractClass(AbstractSentry::class);
-		$setMethod = new SentryMethod(
-			new SentryAccess('set'),
-			'setFoo',
-			Visibility::get(Visibility::VISIBILITY_PUBLIC)
-		);
-		$propertyMetadata = new PropertyMetadata(
-			'fooProperty',
-			FooClass::class,
-			'stdClass',
-			new SentryIdentificator('stdClass'),
-			false,
-			[
-				$setMethod,
-			],
-			null
-		);
+		yield 'set object' => (function (): array {
+			$sentryMethod = new SentryMethod(
+				new SentryAccess('set'),
+				'setFoo',
+				Visibility::get(Visibility::VISIBILITY_PUBLIC)
+			);
 
-		$method = '
+			return [
+				'propertyMetadata' => new PropertyMetadata(
+					'fooProperty',
+					FooClass::class,
+					'stdClass',
+					new SentryIdentificator('stdClass'),
+					false,
+					[
+						$sentryMethod,
+					],
+					null
+				),
+				'sentryMethod' => $sentryMethod,
+				'expectedGeneratedMethod' => '
 	/**
 	 * Generated stdClass setter
 	 *
@@ -214,8 +219,27 @@ class AbstractSentryTest extends \PHPUnit\Framework\TestCase
 	public function setFoo($newValue)
 	{
 		$this->fooProperty = $newValue;
-	}';
-		Assert::assertSame($method, $sentry->generateMethod($propertyMetadata, $setMethod));
+	}',
+			];
+		})();
+	}
+
+	/**
+	 * @dataProvider generateMethodDataProvider
+	 *
+	 * @param \Consistence\Sentry\Metadata\PropertyMetadata $propertyMetadata
+	 * @param \Consistence\Sentry\Metadata\SentryMethod $sentryMethod
+	 * @param string $expectedGeneratedMethod
+	 */
+	public function testGenerateMethod(
+		PropertyMetadata $propertyMetadata,
+		SentryMethod $sentryMethod,
+		string $expectedGeneratedMethod
+	): void
+	{
+		$sentry = $this->getMockForAbstractClass(AbstractSentry::class);
+
+		Assert::assertSame($expectedGeneratedMethod, $sentry->generateMethod($propertyMetadata, $sentryMethod));
 	}
 
 	public function testGenerateUnsupportedSentryAccess(): void

--- a/tests/Type/AbstractSentryTest.php
+++ b/tests/Type/AbstractSentryTest.php
@@ -40,7 +40,7 @@ class AbstractSentryTest extends \PHPUnit\Framework\TestCase
 		$sentryAccess = new SentryAccess('xxx');
 		try {
 			$sentry->getDefaultMethodName($sentryAccess, 'foo');
-			Assert::fail();
+			Assert::fail('Exception expected');
 		} catch (\Consistence\Sentry\Type\SentryAccessNotSupportedException $e) {
 			Assert::assertSame($sentryAccess, $e->getSentryAccess());
 			Assert::assertSame('MockAbstractSentryTest', $e->getSentryClassName());
@@ -213,7 +213,7 @@ class AbstractSentryTest extends \PHPUnit\Framework\TestCase
 		$args = [];
 		try {
 			$sentry->generateMethod($propertyMetadata, $xxxMethod, $args);
-			Assert::fail();
+			Assert::fail('Exception expected');
 		} catch (\Consistence\Sentry\Type\SentryAccessNotSupportedForPropertyException $e) {
 			Assert::assertSame($propertyMetadata, $e->getProperty());
 			Assert::assertSame($xxxSentryAccess, $e->getSentryAccess());

--- a/tests/Type/AbstractSentryTest.php
+++ b/tests/Type/AbstractSentryTest.php
@@ -89,7 +89,6 @@ class AbstractSentryTest extends \PHPUnit\Framework\TestCase
 		$this->assertSame($method, $sentry->generateMethod($propertyMetadata, $getMethod));
 	}
 
-
 	public function testGenerateObjectGet(): void
 	{
 		$sentry = $this->getMockForAbstractClass(AbstractSentry::class);

--- a/tests/Type/AbstractSentryTest.php
+++ b/tests/Type/AbstractSentryTest.php
@@ -10,6 +10,7 @@ use Consistence\Sentry\Metadata\SentryAccess;
 use Consistence\Sentry\Metadata\SentryIdentificator;
 use Consistence\Sentry\Metadata\SentryMethod;
 use Consistence\Sentry\Metadata\Visibility;
+use Generator;
 use PHPUnit\Framework\Assert;
 
 class AbstractSentryTest extends \PHPUnit\Framework\TestCase
@@ -25,12 +26,40 @@ class AbstractSentryTest extends \PHPUnit\Framework\TestCase
 		], $sentry->getSupportedAccess());
 	}
 
-	public function testDefaultMethodNames(): void
+	/**
+	 * @return mixed[][]|\Generator
+	 */
+	public function getDefaultMethodNameDataProvider(): Generator
+	{
+		yield 'get' => [
+			'sentryAccess' => new SentryAccess('get'),
+			'propertyName' => 'foo',
+			'expectedDefaultMethodName' => 'getFoo',
+		];
+
+		yield 'set' => [
+			'sentryAccess' => new SentryAccess('set'),
+			'propertyName' => 'foo',
+			'expectedDefaultMethodName' => 'setFoo',
+		];
+	}
+
+	/**
+	 * @dataProvider getDefaultMethodNameDataProvider
+	 *
+	 * @param \Consistence\Sentry\Metadata\SentryAccess $sentryAccess
+	 * @param string $propertyName
+	 * @param string $expectedDefaultMethodName
+	 */
+	public function testGetDefaultMethodName(
+		SentryAccess $sentryAccess,
+		string $propertyName,
+		string $expectedDefaultMethodName
+	): void
 	{
 		$sentry = $this->getMockForAbstractClass(AbstractSentry::class);
 
-		Assert::assertSame('getFoo', $sentry->getDefaultMethodName(new SentryAccess('get'), 'foo'));
-		Assert::assertSame('setFoo', $sentry->getDefaultMethodName(new SentryAccess('set'), 'foo'));
+		Assert::assertSame($expectedDefaultMethodName, $sentry->getDefaultMethodName($sentryAccess, $propertyName));
 	}
 
 	public function testDefaultMethodNameUnsupportedSentryAccess(): void

--- a/tests/Type/AbstractSentryTest.php
+++ b/tests/Type/AbstractSentryTest.php
@@ -10,6 +10,7 @@ use Consistence\Sentry\Metadata\SentryAccess;
 use Consistence\Sentry\Metadata\SentryIdentificator;
 use Consistence\Sentry\Metadata\SentryMethod;
 use Consistence\Sentry\Metadata\Visibility;
+use PHPUnit\Framework\Assert;
 
 class AbstractSentryTest extends \PHPUnit\Framework\TestCase
 {
@@ -18,7 +19,7 @@ class AbstractSentryTest extends \PHPUnit\Framework\TestCase
 	{
 		$sentry = $this->getMockForAbstractClass(AbstractSentry::class);
 
-		$this->assertEquals([
+		Assert::assertEquals([
 			new SentryAccess('get'),
 			new SentryAccess('set'),
 		], $sentry->getSupportedAccess());
@@ -28,8 +29,8 @@ class AbstractSentryTest extends \PHPUnit\Framework\TestCase
 	{
 		$sentry = $this->getMockForAbstractClass(AbstractSentry::class);
 
-		$this->assertSame('getFoo', $sentry->getDefaultMethodName(new SentryAccess('get'), 'foo'));
-		$this->assertSame('setFoo', $sentry->getDefaultMethodName(new SentryAccess('set'), 'foo'));
+		Assert::assertSame('getFoo', $sentry->getDefaultMethodName(new SentryAccess('get'), 'foo'));
+		Assert::assertSame('setFoo', $sentry->getDefaultMethodName(new SentryAccess('set'), 'foo'));
 	}
 
 	public function testDefaultMethodNameUnsupportedSentryAccess(): void
@@ -39,10 +40,10 @@ class AbstractSentryTest extends \PHPUnit\Framework\TestCase
 		$sentryAccess = new SentryAccess('xxx');
 		try {
 			$sentry->getDefaultMethodName($sentryAccess, 'foo');
-			$this->fail();
+			Assert::fail();
 		} catch (\Consistence\Sentry\Type\SentryAccessNotSupportedException $e) {
-			$this->assertSame($sentryAccess, $e->getSentryAccess());
-			$this->assertSame('MockAbstractSentryTest', $e->getSentryClassName());
+			Assert::assertSame($sentryAccess, $e->getSentryAccess());
+			Assert::assertSame('MockAbstractSentryTest', $e->getSentryClassName());
 		}
 	}
 
@@ -50,7 +51,7 @@ class AbstractSentryTest extends \PHPUnit\Framework\TestCase
 	{
 		$sentry = $this->getMockForAbstractClass(AbstractSentry::class);
 
-		$this->assertEmpty($sentry->getTargetAssociationAccessForAccess(
+		Assert::assertEmpty($sentry->getTargetAssociationAccessForAccess(
 			new SentryAccess('get'),
 			BidirectionalAssociationType::get(BidirectionalAssociationType::ONE)
 		));
@@ -86,7 +87,7 @@ class AbstractSentryTest extends \PHPUnit\Framework\TestCase
 	{
 		return $this->fooProperty;
 	}';
-		$this->assertSame($method, $sentry->generateMethod($propertyMetadata, $getMethod));
+		Assert::assertSame($method, $sentry->generateMethod($propertyMetadata, $getMethod));
 	}
 
 	public function testGenerateObjectGet(): void
@@ -119,7 +120,7 @@ class AbstractSentryTest extends \PHPUnit\Framework\TestCase
 	{
 		return $this->fooProperty;
 	}';
-		$this->assertSame($method, $sentry->generateMethod($propertyMetadata, $getMethod));
+		Assert::assertSame($method, $sentry->generateMethod($propertyMetadata, $getMethod));
 	}
 
 	public function testGenerateSet(): void
@@ -152,7 +153,7 @@ class AbstractSentryTest extends \PHPUnit\Framework\TestCase
 	{
 		$this->fooProperty = $newValue;
 	}';
-		$this->assertSame($method, $sentry->generateMethod($propertyMetadata, $setMethod));
+		Assert::assertSame($method, $sentry->generateMethod($propertyMetadata, $setMethod));
 	}
 
 	public function testGenerateObjectSet(): void
@@ -185,7 +186,7 @@ class AbstractSentryTest extends \PHPUnit\Framework\TestCase
 	{
 		$this->fooProperty = $newValue;
 	}';
-		$this->assertSame($method, $sentry->generateMethod($propertyMetadata, $setMethod));
+		Assert::assertSame($method, $sentry->generateMethod($propertyMetadata, $setMethod));
 	}
 
 	public function testGenerateUnsupportedSentryAccess(): void
@@ -212,11 +213,11 @@ class AbstractSentryTest extends \PHPUnit\Framework\TestCase
 		$args = [];
 		try {
 			$sentry->generateMethod($propertyMetadata, $xxxMethod, $args);
-			$this->fail();
+			Assert::fail();
 		} catch (\Consistence\Sentry\Type\SentryAccessNotSupportedForPropertyException $e) {
-			$this->assertSame($propertyMetadata, $e->getProperty());
-			$this->assertSame($xxxSentryAccess, $e->getSentryAccess());
-			$this->assertSame(get_class($sentry), $e->getSentryClassName());
+			Assert::assertSame($propertyMetadata, $e->getProperty());
+			Assert::assertSame($xxxSentryAccess, $e->getSentryAccess());
+			Assert::assertSame(get_class($sentry), $e->getSentryClassName());
 		}
 	}
 

--- a/tests/Type/CollectionTest.php
+++ b/tests/Type/CollectionTest.php
@@ -9,6 +9,7 @@ use Consistence\Sentry\Metadata\SentryAccess;
 use Consistence\Sentry\Metadata\SentryIdentificator;
 use Consistence\Sentry\Metadata\SentryMethod;
 use Consistence\Sentry\Metadata\Visibility;
+use Generator;
 use PHPUnit\Framework\Assert;
 
 class CollectionTest extends \PHPUnit\Framework\TestCase
@@ -27,15 +28,58 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
 		], $collection->getSupportedAccess());
 	}
 
-	public function testDefaultMethodNames(): void
+	/**
+	 * @return mixed[][]|\Generator
+	 */
+	public function getDefaultMethodNameDataProvider(): Generator
+	{
+		yield 'get' => [
+			'sentryAccess' => new SentryAccess('get'),
+			'propertyName' => 'children',
+			'expectedDefaultMethodName' => 'getChildren',
+		];
+
+		yield 'set' => [
+			'sentryAccess' => new SentryAccess('set'),
+			'propertyName' => 'children',
+			'expectedDefaultMethodName' => 'setChildren',
+		];
+
+		yield 'add' => [
+			'sentryAccess' => new SentryAccess('add'),
+			'propertyName' => 'children',
+			'expectedDefaultMethodName' => 'addChild',
+		];
+
+		yield 'remove' => [
+			'sentryAccess' => new SentryAccess('remove'),
+			'propertyName' => 'children',
+			'expectedDefaultMethodName' => 'removeChild',
+		];
+
+		yield 'contains' => [
+			'sentryAccess' => new SentryAccess('contains'),
+			'propertyName' => 'children',
+			'expectedDefaultMethodName' => 'containsChild',
+		];
+	}
+
+	/**
+	 * @dataProvider getDefaultMethodNameDataProvider
+	 *
+	 * @param \Consistence\Sentry\Metadata\SentryAccess $sentryAccess
+	 * @param string $propertyName
+	 * @param string $expectedDefaultMethodName
+	 */
+	public function testGetDefaultMethodName(
+		SentryAccess $sentryAccess,
+		string $propertyName,
+		string $expectedDefaultMethodName
+	): void
 	{
 		$collection = new CollectionType();
 
-		Assert::assertSame('getChildren', $collection->getDefaultMethodName(new SentryAccess('get'), 'children'));
-		Assert::assertSame('setChildren', $collection->getDefaultMethodName(new SentryAccess('set'), 'children'));
-		Assert::assertSame('addChild', $collection->getDefaultMethodName(new SentryAccess('add'), 'children'));
-		Assert::assertSame('removeChild', $collection->getDefaultMethodName(new SentryAccess('remove'), 'children'));
-		Assert::assertSame('containsChild', $collection->getDefaultMethodName(new SentryAccess('contains'), 'children'));
+		Assert::assertSame($expectedDefaultMethodName, $collection->getDefaultMethodName($sentryAccess, $propertyName));
 	}
 
 	public function testGenerateGet(): void

--- a/tests/Type/CollectionTest.php
+++ b/tests/Type/CollectionTest.php
@@ -82,27 +82,32 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
 		Assert::assertSame($expectedDefaultMethodName, $collection->getDefaultMethodName($sentryAccess, $propertyName));
 	}
 
-	public function testGenerateGet(): void
+	/**
+	 * @return mixed[][]|\Generator
+	 */
+	public function generateMethodDataProvider(): Generator
 	{
-		$collection = new CollectionType();
-		$getMethod = new SentryMethod(
-			new SentryAccess('get'),
-			'getFoo',
-			Visibility::get(Visibility::VISIBILITY_PUBLIC)
-		);
-		$propertyMetadata = new PropertyMetadata(
-			'children',
-			FooClass::class,
-			'int',
-			new SentryIdentificator('int[]'),
-			false,
-			[
-				$getMethod,
-			],
-			null
-		);
+		yield 'get' => (function (): array {
+			$sentryMethod = new SentryMethod(
+				new SentryAccess('get'),
+				'getFoo',
+				Visibility::get(Visibility::VISIBILITY_PUBLIC)
+			);
 
-		$method = '
+			return [
+				'propertyMetadata' => new PropertyMetadata(
+					'children',
+					FooClass::class,
+					'int',
+					new SentryIdentificator('int[]'),
+					false,
+					[
+						$sentryMethod,
+					],
+					null
+				),
+				'sentryMethod' => $sentryMethod,
+				'expectedGeneratedMethod' => '
 	/**
 	 * Generated int collection getter
 	 *
@@ -111,31 +116,31 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
 	public function getFoo()
 	{
 		return $this->children;
-	}';
-		Assert::assertSame($method, $collection->generateMethod($propertyMetadata, $getMethod));
-	}
+	}',
+			];
+		})();
 
-	public function testGenerateSet(): void
-	{
-		$collection = new CollectionType();
-		$setMethod = new SentryMethod(
-			new SentryAccess('set'),
-			'setFoo',
-			Visibility::get(Visibility::VISIBILITY_PUBLIC)
-		);
-		$propertyMetadata = new PropertyMetadata(
-			'children',
-			FooClass::class,
-			'int',
-			new SentryIdentificator('int[]'),
-			false,
-			[
-				$setMethod,
-			],
-			null
-		);
+		yield 'set' => (function (): array {
+			$sentryMethod = new SentryMethod(
+				new SentryAccess('set'),
+				'setFoo',
+				Visibility::get(Visibility::VISIBILITY_PUBLIC)
+			);
 
-		$method = '
+			return [
+				'propertyMetadata' => new PropertyMetadata(
+					'children',
+					FooClass::class,
+					'int',
+					new SentryIdentificator('int[]'),
+					false,
+					[
+						$sentryMethod,
+					],
+					null
+				),
+				'sentryMethod' => $sentryMethod,
+				'expectedGeneratedMethod' => '
 	/**
 	 * Generated int collection setter
 	 *
@@ -152,31 +157,31 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
 				$collection[] = $el;
 			}
 		}
-	}';
-		Assert::assertSame($method, $collection->generateMethod($propertyMetadata, $setMethod));
-	}
+	}',
+			];
+		})();
 
-	public function testGenerateContains(): void
-	{
-		$collection = new CollectionType();
-		$containsMethod = new SentryMethod(
-			new SentryAccess('contains'),
-			'containsFoo',
-			Visibility::get(Visibility::VISIBILITY_PUBLIC)
-		);
-		$propertyMetadata = new PropertyMetadata(
-			'children',
-			FooClass::class,
-			'int',
-			new SentryIdentificator('int[]'),
-			false,
-			[
-				$containsMethod,
-			],
-			null
-		);
+		yield 'contains' => (function (): array {
+			$sentryMethod = new SentryMethod(
+				new SentryAccess('contains'),
+				'containsFoo',
+				Visibility::get(Visibility::VISIBILITY_PUBLIC)
+			);
 
-		$method = '
+			return [
+				'propertyMetadata' => new PropertyMetadata(
+					'children',
+					FooClass::class,
+					'int',
+					new SentryIdentificator('int[]'),
+					false,
+					[
+						$sentryMethod,
+					],
+					null
+				),
+				'sentryMethod' => $sentryMethod,
+				'expectedGeneratedMethod' => '
 	/**
 	 * Generated int collection contains
 	 *
@@ -187,31 +192,31 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
 	{
 		\Consistence\Type\Type::checkType($value, \'int\');
 		return \Consistence\Type\ArrayType\ArrayType::containsValue($this->children, $value);
-	}';
-		Assert::assertSame($method, $collection->generateMethod($propertyMetadata, $containsMethod));
-	}
+	}',
+			];
+		})();
 
-	public function testGenerateAdd(): void
-	{
-		$collection = new CollectionType();
-		$addMethod = new SentryMethod(
-			new SentryAccess('add'),
-			'addFoo',
-			Visibility::get(Visibility::VISIBILITY_PUBLIC)
-		);
-		$propertyMetadata = new PropertyMetadata(
-			'children',
-			FooClass::class,
-			'int',
-			new SentryIdentificator('int[]'),
-			false,
-			[
-				$addMethod,
-			],
-			null
-		);
+		yield 'add' => (function (): array {
+			$sentryMethod = new SentryMethod(
+				new SentryAccess('add'),
+				'addFoo',
+				Visibility::get(Visibility::VISIBILITY_PUBLIC)
+			);
 
-		$method = '
+			return [
+				'propertyMetadata' => new PropertyMetadata(
+					'children',
+					FooClass::class,
+					'int',
+					new SentryIdentificator('int[]'),
+					false,
+					[
+						$sentryMethod,
+					],
+					null
+				),
+				'sentryMethod' => $sentryMethod,
+				'expectedGeneratedMethod' => '
 	/**
 	 * Generated int collection add
 	 *
@@ -229,31 +234,31 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
 		}
 
 		return false;
-	}';
-		Assert::assertSame($method, $collection->generateMethod($propertyMetadata, $addMethod));
-	}
+	}',
+			];
+		})();
 
-	public function testGenerateRemove(): void
-	{
-		$collection = new CollectionType();
-		$removeMethod = new SentryMethod(
-			new SentryAccess('remove'),
-			'removeFoo',
-			Visibility::get(Visibility::VISIBILITY_PUBLIC)
-		);
-		$propertyMetadata = new PropertyMetadata(
-			'children',
-			FooClass::class,
-			'int',
-			new SentryIdentificator('int[]'),
-			false,
-			[
-				$removeMethod,
-			],
-			null
-		);
+		yield 'remove' => (function (): array {
+			$sentryMethod = new SentryMethod(
+				new SentryAccess('remove'),
+				'removeFoo',
+				Visibility::get(Visibility::VISIBILITY_PUBLIC)
+			);
 
-		$method = '
+			return [
+				'propertyMetadata' => new PropertyMetadata(
+					'children',
+					FooClass::class,
+					'int',
+					new SentryIdentificator('int[]'),
+					false,
+					[
+						$sentryMethod,
+					],
+					null
+				),
+				'sentryMethod' => $sentryMethod,
+				'expectedGeneratedMethod' => '
 	/**
 	 * Generated int collection remove
 	 *
@@ -264,8 +269,27 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
 	{
 		\Consistence\Type\Type::checkType($value, \'int\');
 		return \Consistence\Type\ArrayType\ArrayType::removeValue($this->children, $value);
-	}';
-		Assert::assertSame($method, $collection->generateMethod($propertyMetadata, $removeMethod));
+	}',
+			];
+		})();
+	}
+
+	/**
+	 * @dataProvider generateMethodDataProvider
+	 *
+	 * @param \Consistence\Sentry\Metadata\PropertyMetadata $propertyMetadata
+	 * @param \Consistence\Sentry\Metadata\SentryMethod $sentryMethod
+	 * @param string $expectedGeneratedMethod
+	 */
+	public function testGenerateMethod(
+		PropertyMetadata $propertyMetadata,
+		SentryMethod $sentryMethod,
+		string $expectedGeneratedMethod
+	): void
+	{
+		$collection = new CollectionType();
+
+		Assert::assertSame($expectedGeneratedMethod, $collection->generateMethod($propertyMetadata, $sentryMethod));
 	}
 
 }

--- a/tests/Type/CollectionTest.php
+++ b/tests/Type/CollectionTest.php
@@ -9,6 +9,7 @@ use Consistence\Sentry\Metadata\SentryAccess;
 use Consistence\Sentry\Metadata\SentryIdentificator;
 use Consistence\Sentry\Metadata\SentryMethod;
 use Consistence\Sentry\Metadata\Visibility;
+use PHPUnit\Framework\Assert;
 
 class CollectionTest extends \PHPUnit\Framework\TestCase
 {
@@ -17,7 +18,7 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
 	{
 		$collection = new CollectionType();
 
-		$this->assertEquals([
+		Assert::assertEquals([
 			new SentryAccess('get'),
 			new SentryAccess('set'),
 			new SentryAccess('add'),
@@ -30,11 +31,11 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
 	{
 		$collection = new CollectionType();
 
-		$this->assertSame('getChildren', $collection->getDefaultMethodName(new SentryAccess('get'), 'children'));
-		$this->assertSame('setChildren', $collection->getDefaultMethodName(new SentryAccess('set'), 'children'));
-		$this->assertSame('addChild', $collection->getDefaultMethodName(new SentryAccess('add'), 'children'));
-		$this->assertSame('removeChild', $collection->getDefaultMethodName(new SentryAccess('remove'), 'children'));
-		$this->assertSame('containsChild', $collection->getDefaultMethodName(new SentryAccess('contains'), 'children'));
+		Assert::assertSame('getChildren', $collection->getDefaultMethodName(new SentryAccess('get'), 'children'));
+		Assert::assertSame('setChildren', $collection->getDefaultMethodName(new SentryAccess('set'), 'children'));
+		Assert::assertSame('addChild', $collection->getDefaultMethodName(new SentryAccess('add'), 'children'));
+		Assert::assertSame('removeChild', $collection->getDefaultMethodName(new SentryAccess('remove'), 'children'));
+		Assert::assertSame('containsChild', $collection->getDefaultMethodName(new SentryAccess('contains'), 'children'));
 	}
 
 	public function testGenerateGet(): void
@@ -67,7 +68,7 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
 	{
 		return $this->children;
 	}';
-		$this->assertSame($method, $collection->generateMethod($propertyMetadata, $getMethod));
+		Assert::assertSame($method, $collection->generateMethod($propertyMetadata, $getMethod));
 	}
 
 	public function testGenerateSet(): void
@@ -108,7 +109,7 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
 			}
 		}
 	}';
-		$this->assertSame($method, $collection->generateMethod($propertyMetadata, $setMethod));
+		Assert::assertSame($method, $collection->generateMethod($propertyMetadata, $setMethod));
 	}
 
 	public function testGenerateContains(): void
@@ -143,7 +144,7 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
 		\Consistence\Type\Type::checkType($value, \'int\');
 		return \Consistence\Type\ArrayType\ArrayType::containsValue($this->children, $value);
 	}';
-		$this->assertSame($method, $collection->generateMethod($propertyMetadata, $containsMethod));
+		Assert::assertSame($method, $collection->generateMethod($propertyMetadata, $containsMethod));
 	}
 
 	public function testGenerateAdd(): void
@@ -185,7 +186,7 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
 
 		return false;
 	}';
-		$this->assertSame($method, $collection->generateMethod($propertyMetadata, $addMethod));
+		Assert::assertSame($method, $collection->generateMethod($propertyMetadata, $addMethod));
 	}
 
 	public function testGenerateRemove(): void
@@ -220,7 +221,7 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
 		\Consistence\Type\Type::checkType($value, \'int\');
 		return \Consistence\Type\ArrayType\ArrayType::removeValue($this->children, $value);
 	}';
-		$this->assertSame($method, $collection->generateMethod($propertyMetadata, $removeMethod));
+		Assert::assertSame($method, $collection->generateMethod($propertyMetadata, $removeMethod));
 	}
 
 }

--- a/tests/Type/SimpleTypeTest.php
+++ b/tests/Type/SimpleTypeTest.php
@@ -9,6 +9,7 @@ use Consistence\Sentry\Metadata\SentryAccess;
 use Consistence\Sentry\Metadata\SentryIdentificator;
 use Consistence\Sentry\Metadata\SentryMethod;
 use Consistence\Sentry\Metadata\Visibility;
+use PHPUnit\Framework\Assert;
 
 class SimpleTypeTest extends \PHPUnit\Framework\TestCase
 {
@@ -43,7 +44,7 @@ class SimpleTypeTest extends \PHPUnit\Framework\TestCase
 	{
 		return $this->fooProperty;
 	}';
-		$this->assertSame($method, $integerSentry->generateMethod($propertyMetadata, $getMethod));
+		Assert::assertSame($method, $integerSentry->generateMethod($propertyMetadata, $getMethod));
 	}
 
 	public function testGenerateNullableGet(): void
@@ -76,7 +77,7 @@ class SimpleTypeTest extends \PHPUnit\Framework\TestCase
 	{
 		return $this->fooProperty;
 	}';
-		$this->assertSame($method, $integerSentry->generateMethod($propertyMetadata, $getMethod));
+		Assert::assertSame($method, $integerSentry->generateMethod($propertyMetadata, $getMethod));
 	}
 
 	public function testGenerateSet(): void
@@ -110,7 +111,7 @@ class SimpleTypeTest extends \PHPUnit\Framework\TestCase
 		\Consistence\Type\Type::checkType($newValue, \'int\');
 		$this->fooProperty = $newValue;
 	}';
-		$this->assertSame($method, $integerSentry->generateMethod($propertyMetadata, $setMethod));
+		Assert::assertSame($method, $integerSentry->generateMethod($propertyMetadata, $setMethod));
 	}
 
 	public function testGenerateSetNullable(): void
@@ -144,7 +145,7 @@ class SimpleTypeTest extends \PHPUnit\Framework\TestCase
 		\Consistence\Type\Type::checkType($newValue, \'int|null\');
 		$this->fooProperty = $newValue;
 	}';
-		$this->assertSame($method, $integerSentry->generateMethod($propertyMetadata, $setMethod));
+		Assert::assertSame($method, $integerSentry->generateMethod($propertyMetadata, $setMethod));
 	}
 
 }

--- a/tests/Type/SimpleTypeTest.php
+++ b/tests/Type/SimpleTypeTest.php
@@ -9,32 +9,38 @@ use Consistence\Sentry\Metadata\SentryAccess;
 use Consistence\Sentry\Metadata\SentryIdentificator;
 use Consistence\Sentry\Metadata\SentryMethod;
 use Consistence\Sentry\Metadata\Visibility;
+use Generator;
 use PHPUnit\Framework\Assert;
 
 class SimpleTypeTest extends \PHPUnit\Framework\TestCase
 {
 
-	public function testGenerateGet(): void
+	/**
+	 * @return mixed[][]|\Generator
+	 */
+	public function generateMethodDataProvider(): Generator
 	{
-		$integerSentry = new SimpleType();
-		$getMethod = new SentryMethod(
-			new SentryAccess('get'),
-			'getFoo',
-			Visibility::get(Visibility::VISIBILITY_PUBLIC)
-		);
-		$propertyMetadata = new PropertyMetadata(
-			'fooProperty',
-			FooClass::class,
-			'int',
-			new SentryIdentificator('int'),
-			false,
-			[
-				$getMethod,
-			],
-			null
-		);
+		yield 'get' => (function (): array {
+			$sentryMethod = new SentryMethod(
+				new SentryAccess('get'),
+				'getFoo',
+				Visibility::get(Visibility::VISIBILITY_PUBLIC)
+			);
 
-		$method = '
+			return [
+				'propertyMetadata' => new PropertyMetadata(
+					'fooProperty',
+					FooClass::class,
+					'int',
+					new SentryIdentificator('int'),
+					false,
+					[
+						$sentryMethod,
+					],
+					null
+				),
+				'sentryMethod' => $sentryMethod,
+				'expectedGeneratedMethod' => '
 	/**
 	 * Generated int getter
 	 *
@@ -43,31 +49,31 @@ class SimpleTypeTest extends \PHPUnit\Framework\TestCase
 	public function getFoo()
 	{
 		return $this->fooProperty;
-	}';
-		Assert::assertSame($method, $integerSentry->generateMethod($propertyMetadata, $getMethod));
-	}
+	}',
+			];
+		})();
 
-	public function testGenerateNullableGet(): void
-	{
-		$integerSentry = new SimpleType();
-		$getMethod = new SentryMethod(
-			new SentryAccess('get'),
-			'getFoo',
-			Visibility::get(Visibility::VISIBILITY_PUBLIC)
-		);
-		$propertyMetadata = new PropertyMetadata(
-			'fooProperty',
-			FooClass::class,
-			'int',
-			new SentryIdentificator('int|null'),
-			true,
-			[
-				$getMethod,
-			],
-			null
-		);
+		yield 'get nullable' => (function (): array {
+			$sentryMethod = new SentryMethod(
+				new SentryAccess('get'),
+				'getFoo',
+				Visibility::get(Visibility::VISIBILITY_PUBLIC)
+			);
 
-		$method = '
+			return [
+				'propertyMetadata' => new PropertyMetadata(
+					'fooProperty',
+					FooClass::class,
+					'int',
+					new SentryIdentificator('int|null'),
+					true,
+					[
+						$sentryMethod,
+					],
+					null
+				),
+				'sentryMethod' => $sentryMethod,
+				'expectedGeneratedMethod' => '
 	/**
 	 * Generated int getter
 	 *
@@ -76,31 +82,31 @@ class SimpleTypeTest extends \PHPUnit\Framework\TestCase
 	public function getFoo()
 	{
 		return $this->fooProperty;
-	}';
-		Assert::assertSame($method, $integerSentry->generateMethod($propertyMetadata, $getMethod));
-	}
+	}',
+			];
+		})();
 
-	public function testGenerateSet(): void
-	{
-		$integerSentry = new SimpleType();
-		$setMethod = new SentryMethod(
-			new SentryAccess('set'),
-			'setFoo',
-			Visibility::get(Visibility::VISIBILITY_PUBLIC)
-		);
-		$propertyMetadata = new PropertyMetadata(
-			'fooProperty',
-			FooClass::class,
-			'int',
-			new SentryIdentificator('int'),
-			false,
-			[
-				$setMethod,
-			],
-			null
-		);
+		yield 'set' => (function (): array {
+			$sentryMethod = new SentryMethod(
+				new SentryAccess('set'),
+				'setFoo',
+				Visibility::get(Visibility::VISIBILITY_PUBLIC)
+			);
 
-		$method = '
+			return [
+				'propertyMetadata' => new PropertyMetadata(
+					'fooProperty',
+					FooClass::class,
+					'int',
+					new SentryIdentificator('int'),
+					false,
+					[
+						$sentryMethod,
+					],
+					null
+				),
+				'sentryMethod' => $sentryMethod,
+				'expectedGeneratedMethod' => '
 	/**
 	 * Generated int setter
 	 *
@@ -110,31 +116,31 @@ class SimpleTypeTest extends \PHPUnit\Framework\TestCase
 	{
 		\Consistence\Type\Type::checkType($newValue, \'int\');
 		$this->fooProperty = $newValue;
-	}';
-		Assert::assertSame($method, $integerSentry->generateMethod($propertyMetadata, $setMethod));
-	}
+	}',
+			];
+		})();
 
-	public function testGenerateSetNullable(): void
-	{
-		$integerSentry = new SimpleType();
-		$setMethod = new SentryMethod(
-			new SentryAccess('set'),
-			'setFoo',
-			Visibility::get(Visibility::VISIBILITY_PUBLIC)
-		);
-		$propertyMetadata = new PropertyMetadata(
-			'fooProperty',
-			FooClass::class,
-			'int',
-			new SentryIdentificator('int|null'),
-			true,
-			[
-				$setMethod,
-			],
-			null
-		);
+		yield 'set nullable' => (function (): array {
+			$sentryMethod = new SentryMethod(
+				new SentryAccess('set'),
+				'setFoo',
+				Visibility::get(Visibility::VISIBILITY_PUBLIC)
+			);
 
-		$method = '
+			return [
+				'propertyMetadata' => new PropertyMetadata(
+					'fooProperty',
+					FooClass::class,
+					'int',
+					new SentryIdentificator('int|null'),
+					true,
+					[
+						$sentryMethod,
+					],
+					null
+				),
+				'sentryMethod' => $sentryMethod,
+				'expectedGeneratedMethod' => '
 	/**
 	 * Generated int setter
 	 *
@@ -144,8 +150,27 @@ class SimpleTypeTest extends \PHPUnit\Framework\TestCase
 	{
 		\Consistence\Type\Type::checkType($newValue, \'int|null\');
 		$this->fooProperty = $newValue;
-	}';
-		Assert::assertSame($method, $integerSentry->generateMethod($propertyMetadata, $setMethod));
+	}',
+			];
+		})();
+	}
+
+	/**
+	 * @dataProvider generateMethodDataProvider
+	 *
+	 * @param \Consistence\Sentry\Metadata\PropertyMetadata $propertyMetadata
+	 * @param \Consistence\Sentry\Metadata\SentryMethod $sentryMethod
+	 * @param string $expectedGeneratedMethod
+	 */
+	public function testGenerateMethod(
+		PropertyMetadata $propertyMetadata,
+		SentryMethod $sentryMethod,
+		string $expectedGeneratedMethod
+	): void
+	{
+		$integerSentry = new SimpleType();
+
+		Assert::assertSame($expectedGeneratedMethod, $integerSentry->generateMethod($propertyMetadata, $sentryMethod));
 	}
 
 }


### PR DESCRIPTION
- [x] stop calling static methods in tests as non-static
- [x] use assertSame() where assertEquals() is not explicitly needed
- [x] use assertCount() after assertContains() for array comparison
- [x] add missing Assert::fail() in try+catch blocks when expecting exceptions
- [x] unify Assert::fail() message
- [x] replace Consistence\TestCase::ok() with expectNotToPerformAssertions()
- [x] use try+catch+fail when expecting exceptions with properties
- [x] rename data providers to singular where applicable
- [x] use DataProvider suffix for data providers
- [x] change data provider return type from array to Generator
- [x] declare data provider values on separate lines
- [x] isolate data provider cases using Closures
- [x] name data provider values
- [x] name data provider cases
- [x] extract multiple cases from test methods to data providers
- [x] remove unnecessary private methods for creating mocks