### PR TITLE
Fix class name parsing according to new docs

### DIFF
--- a/src/SentryIdentificatorParser/SentryIdentificatorParser.php
+++ b/src/SentryIdentificatorParser/SentryIdentificatorParser.php
@@ -24,8 +24,8 @@ class SentryIdentificatorParser extends \Consistence\ObjectPrototype
 	{
 		$pattern
 			= '~^'
-			. '(\\\?(?P<' . self::MATCH_SOURCE_CLASS . '>(?:\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)++)' . self::SOURCE_CLASS_SEPARATOR . ')?'
-			. '\\\?(?P<' . self::MATCH_TYPE . '>(?:\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)++)'
+			. '(\\\?(?P<' . self::MATCH_SOURCE_CLASS . '>(?:\\\?[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*)++)' . self::SOURCE_CLASS_SEPARATOR . ')?'
+			. '\\\?(?P<' . self::MATCH_TYPE . '>(?:\\\?[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*)++)'
 			. '(?P<' . self::MATCH_MANY . '>\[\])*'
 			. '(?:\|(?P<' . self::MATCH_NULLABLE . '>(?:null)|(?:NULL)))?'
 			. '(\s|$)~';


### PR DESCRIPTION
https://www.php.net/manual/en/language.oop5.basic.php has updated regular expression vs when this was originally written, see https://github.com/php/doc-en/commit/6187696fb48916b4585a8a837bf725845f7cf3c7 for change.